### PR TITLE
chore(packages): downgraded webpacks file-loader to 4.3.0

### DIFF
--- a/packages/apisuite-client-marketplace/package.json
+++ b/packages/apisuite-client-marketplace/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-react": "7.17.0",
     "eslint-plugin-standard": "4.0.1",
-    "file-loader": "5.0.2",
+    "file-loader": "4.3.0",
     "html-webpack-plugin": "3.2.0",
     "image-webpack-loader": "6.0.0",
     "jest": "24.9.0",

--- a/packages/apisuite-client-portal/package.json
+++ b/packages/apisuite-client-portal/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-react": "7.17.0",
     "eslint-plugin-standard": "4.0.1",
-    "file-loader": "5.0.2",
+    "file-loader": "4.3.0",
     "html-webpack-plugin": "3.2.0",
     "image-webpack-loader": "6.0.0",
     "jest": "24.9.0",

--- a/packages/apisuite-client-sandbox/package.json
+++ b/packages/apisuite-client-sandbox/package.json
@@ -97,7 +97,7 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-react": "7.17.0",
     "eslint-plugin-standard": "4.0.1",
-    "file-loader": "5.0.2",
+    "file-loader": "4.3.0",
     "html-webpack-plugin": "3.2.0",
     "image-webpack-loader": "6.0.0",
     "jest": "24.9.0",

--- a/packages/apisuite-client-sso/package.json
+++ b/packages/apisuite-client-sso/package.json
@@ -89,7 +89,7 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-react": "7.17.0",
     "eslint-plugin-standard": "4.0.1",
-    "file-loader": "5.0.2",
+    "file-loader": "4.3.0",
     "html-webpack-plugin": "3.2.0",
     "image-webpack-loader": "6.0.0",
     "jest": "24.9.0",

--- a/packages/apisuite-platform/package.json
+++ b/packages/apisuite-platform/package.json
@@ -83,7 +83,7 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-react": "7.17.0",
     "eslint-plugin-standard": "4.0.1",
-    "file-loader": "5.0.2",
+    "file-loader": "4.3.0",
     "html-webpack-plugin": "3.2.0",
     "jest": "24.9.0",
     "jest-fetch-mock": "2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6099,10 +6099,10 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
-file-loader@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-5.0.2.tgz#7f3d8b4ac85a5e8df61338cfec95d7405f971caa"
-  integrity sha512-QMiQ+WBkGLejKe81HU8SZ9PovsU/5uaLo0JdTCEXOYv7i7jfAjHZi1tcwp9tSASJPOmmHZtbdCervFmXMH/Dcg==
+file-loader@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-4.3.0.tgz#780f040f729b3d18019f20605f723e844b8a58af"
+  integrity sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"


### PR DESCRIPTION
The >5.0.0 versions of file-loader introduced breaking changes. Downgraded file-loader to 4.3.0.