### PR TITLE
fix(Applications): corrected actions to remove and add subscriptions

### DIFF
--- a/packages/apisuite-client-sandbox/src/containers/Applications/sagas.ts
+++ b/packages/apisuite-client-sandbox/src/containers/Applications/sagas.ts
@@ -234,8 +234,25 @@ export function * addAppSubscriptionSaga (action: AddAppSubscriptionAction) {
       data: qs.stringify(data),
     })
 
+    const updatedApp = {
+      appId: response.app.id,
+      name: response.app.name,
+      description: response.app.description,
+      redirectUrl: response.app.redirect_url,
+      logo: response.app.logo,
+      userId: response.app.userId,
+      subscriptions: response.app.subscriptions,
+      pubUrls: response.app.pub_urls,
+      visibility: response.app.visibility,
+      enable: response.app.enable,
+      createdAt: response.app.createdAt,
+      updatedAt: response.app.updatedAt,
+      clientId: response.app.client_data.client_id,
+      clientSecret: response.app.client_data.client_secret,
+    }
+
     const appIndx = userApps.map((app: AppData) => app.appId).indexOf(action.appId)
-    yield put(addAppSubscriptionSuccess(response.app, appIndx))
+    yield put(addAppSubscriptionSuccess(updatedApp, appIndx))
   } catch {
     console.log('error adding subscription')
   }
@@ -264,8 +281,25 @@ export function * removeAppSubscriptionSaga (action: RemoveAppSubscriptionAction
       data: qs.stringify(data),
     })
 
+    const updatedApp = {
+      appId: response.app.id,
+      name: response.app.name,
+      description: response.app.description,
+      redirectUrl: response.app.redirect_url,
+      logo: response.app.logo,
+      userId: response.app.userId,
+      subscriptions: response.app.subscriptions,
+      pubUrls: response.app.pub_urls,
+      visibility: response.app.visibility,
+      enable: response.app.enable,
+      createdAt: response.app.createdAt,
+      updatedAt: response.app.updatedAt,
+      clientId: response.app.client_data.client_id,
+      clientSecret: response.app.client_data.client_secret,
+    }
+
     const appIndx = userApps.map((app: AppData) => app.appId).indexOf(action.appId)
-    yield put(removeAppSubscriptionSuccess(response.app, appIndx))
+    yield put(removeAppSubscriptionSuccess(updatedApp, appIndx))
   } catch {
     console.log('error removing subscription')
   }


### PR DESCRIPTION
Corrected the bug causing problems removing or adding subscriptions after a subscription for the same app was added or removed, respectively.
- The problem came from an incorrect mapping of the server response to the store's state. The server response with the updated app was being directly used to update the app data in the store. But because a few fields in the API response do not match the front end, namely the app's id which is has the property of `appId` in the store and `id` in the API response, the following requests carried an `undefined` id.
- The problem was fixed by mapping the server response with the updated app to the object in the store as is done for other requests.