### PR TITLE
Disabled the 'Application Visibility' dropdown of the 'App Details' view

### DIFF
--- a/packages/apisuite-client-sandbox/src/containers/Applications/AppDetail/AppDetail.tsx
+++ b/packages/apisuite-client-sandbox/src/containers/Applications/AppDetail/AppDetail.tsx
@@ -255,7 +255,7 @@ const AppDetail: React.FC<AppDetailProps> = (
 
               <InputLabel shrink className={classes.marginBottom}>Application visibility</InputLabel>
 
-              <Select options={selectOptions} selected={selectOptions[0]} />
+              <Select options={selectOptions} selected={selectOptions[0]} disabled={true} />
 
               <br />
 


### PR DESCRIPTION
Just added the `disabled` property (with the value of `true`) to the `AppDetail` container's `Select` component, in accordance to its respective interface.