### PR TITLE
(APIS-342) FE: Login error

### DIFF
--- a/packages/apisuite-client-sandbox/src/components/LoginForm/LoginForm.tsx
+++ b/packages/apisuite-client-sandbox/src/components/LoginForm/LoginForm.tsx
@@ -25,24 +25,32 @@ const LoginForm: React.FC<LoginFormProps> = ({
     email: '',
     password: '',
   })
+  const [inputHasChanged, setInputHasChanged] = React.useState(false)
 
   const handleInputs = (e: FormFieldEvent, err: any) => {
     setInput({
       ...input,
       [e.target.name]: e.target.value,
     })
+
+    setInputHasChanged(true)
+
     const eventTarget = e.target
+
     // @ts-ignore
     setErrors((old: string[]) => parseErrors(eventTarget, err, old || []))
   }
 
-  function handleClickShowPassword () {
+  function handleClickShowPassword() {
     setShowPassword(!showPassword)
   }
 
-  function handleSubmit (e: React.FormEvent<HTMLFormElement> | KeyboardEvent) {
+  function handleSubmit(e: React.FormEvent<HTMLFormElement> | KeyboardEvent) {
     e.preventDefault()
+
     login({ email: input.email, password: input.password })
+
+    setInputHasChanged(false)
   }
 
   React.useEffect(() => {
@@ -73,7 +81,10 @@ const LoginForm: React.FC<LoginFormProps> = ({
         buttonLabel={t('loginForm.button')}
         buttonDisabled={!isFormValid}
         loading={auth.isAuthorizing}
-        error={auth.error}
+        /* We pass an error message to the 'FormCard' component if an authentication error is detected,
+        and as long as a) the previously submitted inputs are not changed, and b) the 'E-mail' or
+        'Password' input fields are not empty. */
+        error={auth.error && !inputHasChanged && (input.email !== "" || input.password !== "") ? auth.error : undefined}
         handleSubmit={handleSubmit}
       >
         <div className={classes.fieldContainer}>
@@ -112,15 +123,15 @@ const LoginForm: React.FC<LoginFormProps> = ({
               InputProps={{
                 classes: { input: classes.passPhrasefield },
                 endAdornment:
-  <InputAdornment position='end'>
-    <IconButton
-      aria-label='toggle password visibility'
-      onClick={handleClickShowPassword}
-      edge='end'
-    >
-      {showPassword ? <Visibility /> : <VisibilityOff />}
-    </IconButton>
-  </InputAdornment>,
+                  <InputAdornment position='end'>
+                    <IconButton
+                      aria-label='toggle password visibility'
+                      onClick={handleClickShowPassword}
+                      edge='end'
+                    >
+                      {showPassword ? <Visibility /> : <VisibilityOff />}
+                    </IconButton>
+                  </InputAdornment>,
               }}
               rules={[
                 { rule: input.password.length > 0, message: t('loginForm.warnings.password') },

--- a/packages/apisuite-client-sandbox/src/containers/Auth/ducks.ts
+++ b/packages/apisuite-client-sandbox/src/containers/Auth/ducks.ts
@@ -3,6 +3,7 @@ import { AuthStore, AuthStoreActionTypes, AuthPayloads } from './types'
 import { Reducer, AnyAction, Dispatch } from 'redux'
 import { History } from 'history'
 import cookie from 'js-cookie'
+import { LOCATION_CHANGE } from 'connected-react-router'
 
 export const LOGIN = 'auth/LOGIN'
 export const LOGIN_USER = 'auth/LOGIN_USER'
@@ -90,6 +91,14 @@ const reducer: Reducer<AuthStore, AnyAction> = (state = initialState, action) =>
         authToken: { $set: undefined },
         isAuthorizing: { $set: false },
       })
+    }
+
+    case LOCATION_CHANGE: {
+      if (action.payload.action === 'POP') {
+        return update(state, {
+          error: { $set: undefined },
+        })
+      }
     }
 
     default:


### PR DESCRIPTION
The error described in [APIS-342](https://cloudoki.atlassian.net/browse/APIS-342) happened because, upon getting an authentication error and moving on to another tab or page, we forgot to **reset** the `auth.error` field of our app's **state**.

By slightly changing the **Auth** container's `ducks` file, this situation was remedied. Some further attention was paid to when the error message should show up and cease to be visible, so now the error message appears immediately after the error occurs (as expected), and disappears upon **changing** or **clearing** any (or both) of the input fields.