### PR TITLE
(APIEC-164) FE: Automatically infer the API and Hydra hostnames

### DIFF
--- a/packages/apisuite-client-sandbox/src/constants/endpoints.ts
+++ b/packages/apisuite-client-sandbox/src/constants/endpoints.ts
@@ -1,8 +1,33 @@
 /** Endpoints constants */
 
-export const AUTH_URL = process.env.AUTH_URL || ''
-export const API_URL = process.env.API_URL || ''
+const { hostname } = window.location;
+
+export const IS_CLOUD = hostname.indexOf(".cloud.apisuite.io") >= 0
+export const AUTH_URL = getAuthUrl()
+export const API_URL = getApiUrl()
 export const SIGNUP_PORT = process.env.SIGNUP_PORT || ''
 export const LOGIN_PORT = process.env.LOGIN_PORT || ''
 export const SUPPORT_URL = process.env.SUPPORT_URL || ''
 export const DOCUMENTATION_URL = process.env.DOCUMENTATION_URL || ''
+
+function getApiUrl() {
+  if (IS_CLOUD) {
+    // Transform the Portal's hostname into the API's hostname
+    // Ex: ${client}.cloud.apisuite.io -> ${client}-apisuite-api.cloud.apisuite.io
+    const apiHostname = hostname.replace(".", "-apisuite-api.")
+    return `https://${apiHostname}`
+  }
+
+  return process.env.API_URL || '';
+}
+
+function getAuthUrl() {
+  if (IS_CLOUD) {
+    // Transform the Portal's hostname into the API's hostname
+    // Ex: ${client}.cloud.apisuite.io -> ${client}-hydraapi.cloud.apisuite.io
+    const authHostname = hostname.replace(".", "-hydraapi.")
+    return `https://${authHostname}`
+  }
+
+  return process.env.AUTH_URL || '';
+}


### PR DESCRIPTION
For the cloud solution so that we can reuse the same Docker image of the Portal for all customers, even though all of them will be running on different hostnames.

When not running at `*.cloud.apisuite.io`, the API and Hydra hostnames continue to be read from the respective env vars.