### PR TITLE
feat(Portal): Fixed the navigation and menu systems

### DIFF
--- a/packages/apisuite-client-sandbox/src/components/Link/Link.tsx
+++ b/packages/apisuite-client-sandbox/src/components/Link/Link.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import { Link as RouterLink, LinkProps } from 'react-router-dom'
+
+type LinkBehaviourProps = {
+  externalTarget?: string,
+} & LinkProps
+
+const Link = React.forwardRef<any, LinkBehaviourProps>((
+  {
+    externalTarget = '_blank',
+    href,
+    to,
+    ...props
+  },
+  ref,
+) => {
+  const destination = href || to
+  if (typeof destination === 'string' && /^https?:\/\//.test(destination)) {
+    return (
+      <a
+        target={externalTarget}
+        href={destination}
+        {...props}
+      >
+        {props.children}
+      </a>
+    )
+  } else {
+    return (
+      <RouterLink ref={ref} to={destination} {...props} />
+    )
+  }
+})
+
+export default Link

--- a/packages/apisuite-client-sandbox/src/components/Link/index.tsx
+++ b/packages/apisuite-client-sandbox/src/components/Link/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Link'

--- a/packages/apisuite-client-sandbox/src/components/Navigation/Navigation.tsx
+++ b/packages/apisuite-client-sandbox/src/components/Navigation/Navigation.tsx
@@ -1,37 +1,19 @@
 import * as React from 'react'
 import clsx from 'clsx'
 import Avatar from '@material-ui/core/Avatar'
+import Tabs from '@material-ui/core/Tabs'
+import Tab from '@material-ui/core/Tab'
 import SvgIcon from 'components/SvgIcon'
+import Link from 'components/Link'
+import useStyles from './styles'
 import './styles.scss'
 import { NavigationProps } from './types'
-
-function getBarValues (parent: React.RefObject<HTMLDivElement>, target: React.RefObject<HTMLDivElement>) {
-  const values = { left: 0, width: 0 }
-
-  if (parent.current != null && target.current != null) {
-    const parentRect = parent.current.getBoundingClientRect()
-    const targetRect = target.current.getBoundingClientRect()
-
-    values.left = targetRect.left - parentRect.left
-    values.width = targetRect.width
-  }
-
-  return values
-}
-
-const tabsRange = Array.from(Array(10).keys())
 
 const Navigation: React.FC<NavigationProps> = (props) => {
   const {
     title,
     className,
     tabs,
-    subTabs,
-    tabIndex,
-    subTabIndex,
-    onTabChange,
-    onSubTabChange,
-    name,
     logoSrc,
     user,
     forceScrolled,
@@ -43,41 +25,20 @@ const Navigation: React.FC<NavigationProps> = (props) => {
     ...rest
   } = props
 
+  const classes = useStyles()
   const [scrollPos, setScrollPos] = React.useState(0)
-  const [barValues, setBarValues] = React.useState({ left: 0, width: 0 })
-  const [subBarValues, setSubBarValues] = React.useState({ left: 0, width: 0 })
-  const tabsRef = React.useRef(null)
-  const subTabsRef = React.useRef(null)
 
-  // TODO: this needs another look into it, right now tabs and sub tabs are limit to 10 each.
-  const refs = tabsRange.map(() => React.useRef(null))
-  const subRefs = tabsRange.map(() => React.useRef(null))
+  const { activeTab, subTabs, activeSubTab } = React.useMemo(() => {
+    const activeTab = tabs.find((tab) => tab.active)
+    const subTabs = !!activeTab && activeTab.subTabs
+    const activeSubTab = !!subTabs && subTabs.find((tab) => tab.active)
+    return { activeTab, subTabs, activeSubTab }
+  }, [tabs])
+
   const scrolled = scrollPos >= 10
 
   function scrollHandler () {
     setScrollPos(window.scrollY)
-  }
-
-  function handleTabClick ({ currentTarget }: React.MouseEvent<HTMLDivElement>) {
-    const { tab, disabled } = currentTarget.dataset
-    const tabIndex = Number(tab) || 0
-
-    if (disabled) {
-      toggleInform()
-    } else if (tabIndex < tabs.length) {
-      onTabChange(tabIndex)
-    }
-  }
-
-  function handleSubTabClick ({ currentTarget }: React.MouseEvent<HTMLDivElement>) {
-    const { tab, disabled } = currentTarget.dataset
-    const tabIndex = Number(tab) || 0
-
-    if (disabled) {
-      toggleInform()
-    } else if (tabIndex < subTabs!.length) {
-      onSubTabChange(tabIndex)
-    }
   }
 
   React.useEffect(() => {
@@ -87,43 +48,32 @@ const Navigation: React.FC<NavigationProps> = (props) => {
     }
   }, [])
 
-  React.useEffect(() => {
-    setBarValues(getBarValues(tabsRef, refs[tabIndex]))
-  }, [tabIndex, tabs])
-
-  React.useEffect(() => {
-    setSubBarValues(getBarValues(subTabsRef, subRefs[subTabIndex]))
-  }, [subTabIndex, subTabs])
-
   return (
     <div className={clsx('navigation', className, { scrolled: scrolled || forceScrolled })} {...rest}>
       <header className={clsx({ scrolled: scrolled || forceScrolled })}>
         <img src={logoSrc} alt='logo' className='img' />
 
-        <h1>{name}</h1>
-
         <nav className={clsx('container', { scrolled: scrolled || forceScrolled })}>
-          <div ref={tabsRef} className='tabs'>
+          <div className='tabs maintabs'>
             <div className='space' />
-
-            {tabs.map((tab, idx) =>
-              <div
-                data-testid={`nav-tab-${idx}`}
-                key={`nav-tab-${idx}`}
-                ref={refs[idx]}
-                data-tab={idx}
-                data-label={tab.label}
-                onClick={handleTabClick}
-                className={clsx('tab', { selected: idx === tabIndex })}
-                data-disabled={tab.disabled}
-              >
-                {tab.label}
-              </div>,
-            )}
-
-            {!(scrolled || forceScrolled) && (
-              <div className='top-bar' style={{ left: barValues.left, width: barValues.width }} />
-            )}
+            <Tabs
+              value={(activeTab && activeTab.route) || false}
+              aria-label='Main navigation'
+              classes={{ indicator: classes.indicatorTop }}
+            >
+              {tabs.map((tab, idx) =>
+                <Tab
+                  component={Link}
+                  key={`nav-tab-${idx}`}
+                  label={tab.label}
+                  to={tab.route}
+                  disableRipple
+                  classes={{ root: classes.tabRoot }}
+                  className={clsx('tab', { selected: tab.active })}
+                  value={tab.route}
+                />,
+              )}
+            </Tabs>
           </div>
         </nav>
 
@@ -137,7 +87,7 @@ const Navigation: React.FC<NavigationProps> = (props) => {
 
       {!!subTabs && (
         <div className={clsx('sub-container', { scrolled: scrolled || forceScrolled })}>
-          <div ref={subTabsRef} className='tabs'>
+          <div className='tabs subtabs'>
             {showBackButton && (
               <div role='button' className='back-btn' onClick={onGoBackCLick}>
                 <SvgIcon name='chevron-left-circle' size={28} /> &nbsp;&nbsp; <span>{backButtonLabel}</span>
@@ -146,23 +96,24 @@ const Navigation: React.FC<NavigationProps> = (props) => {
 
             <div className='space' />
 
-            {subTabs.map((subTab, idx) => (
-              <div
-                data-testid={`nav-sub-tab-${idx}`}
-                key={`nav-sub-tab-${idx}`}
-                ref={subRefs[idx]}
-                data-tab={idx}
-                onClick={handleSubTabClick}
-                className={clsx('tab', 'sub-tab', { selected: idx === subTabIndex })}
-                data-disabled={subTab.disabled}
-              >
-                {subTab.label}
-              </div>
-            ))}
-
-            {(scrolled || forceScrolled) && (
-              <div className='bottom-bar' style={{ left: subBarValues.left, width: subBarValues.width }} />
-            )}
+            <Tabs
+              value={(activeSubTab && activeSubTab.route) || false}
+              aria-label='Main navigation'
+              classes={{ indicator: classes.indicatorBottom }}
+            >
+              {subTabs.map((tab, idx) =>
+                <Tab
+                  component={Link}
+                  key={`nav-sub-tab-${idx}`}
+                  label={tab.label}
+                  to={tab.route}
+                  disableRipple
+                  classes={{ root: classes.tabRoot }}
+                  className={clsx('tab', 'sub-tab', { selected: tab.active })}
+                  value={tab.route}
+                />,
+              )}
+            </Tabs>
           </div>
         </div>
       )}

--- a/packages/apisuite-client-sandbox/src/components/Navigation/styles.scss
+++ b/packages/apisuite-client-sandbox/src/components/Navigation/styles.scss
@@ -82,6 +82,10 @@ $header-space: 50px;
     &.scrolled {
       transform: translateY(0);
       margin-right: 44px;
+
+      .MuiTabs-indicator {
+        display: none;
+      }
     }
   }
 
@@ -102,6 +106,10 @@ $header-space: 50px;
       transform: translateY(0);
       background-color: #E3E3E3;
       color: #333333;
+
+      .MuiTabs-indicator {
+        display: inline;
+      }
     }
   }
 
@@ -119,14 +127,6 @@ $header-space: 50px;
 
     .space {
       flex: 1;
-    }
-
-    .tab {
-      margin: 16px;
-      transition: opacity .2s ease;
-      white-space: nowrap;
-
-      cursor: pointer;
     }
 
     .sub-tab {

--- a/packages/apisuite-client-sandbox/src/components/Navigation/styles.ts
+++ b/packages/apisuite-client-sandbox/src/components/Navigation/styles.ts
@@ -1,35 +1,26 @@
 import { makeStyles } from '@material-ui/styles'
-import { config } from 'constants/global'
 
 export default makeStyles(({
-  snackbar: {
-    display: 'flex',
-    position: 'relative',
-    margin: 8,
-  },
-  content: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    padding: 20,
-    borderRadius: config.dimensions.borderRadius,
-  },
-  icon: {
-    display: 'flex',
-    alignItems: 'center',
-    fontSize: 24,
-    marginRight: 10,
-  },
-  text: {
-    margin: 0,
-  },
-  success: {
-    backgroundColor: config.palette.primary,
+  tabRoot: {
     color: 'white',
+    fontSize: 'inherit',
+    fontWeight: 300,
+    textTransform: 'none',
+    padding: 16,
+    minWidth: 'unset',
+    opacity: 1,
+    '&$selected': {
+      fontWeight: 600,
+    },
   },
-  error: {
-    backgroundColor: config.palette.feedback.error,
-    color: 'white',
+  indicatorTop: {
+    height: 3,
+    backgroundColor: 'white',
+    bottom: 'unset',
+    top: 0,
+  },
+  indicatorBottom: {
+    backgroundColor: 'black',
+    display: 'none',
   },
 }))

--- a/packages/apisuite-client-sandbox/src/components/Navigation/types.ts
+++ b/packages/apisuite-client-sandbox/src/components/Navigation/types.ts
@@ -2,13 +2,7 @@ import { User } from 'containers/Auth/types'
 
 export interface NavigationProps extends React.HTMLAttributes<HTMLDivElement> {
   tabs: TabProps[],
-  subTabs?: SubTabProps[],
-  tabIndex: number,
-  subTabIndex: number,
-  name: string,
   logoSrc: string,
-  onTabChange: (index: number) => void,
-  onSubTabChange: (index: number) => void,
   user?: User,
   forceScrolled?: boolean,
   showBackButton?: boolean,
@@ -22,6 +16,7 @@ export interface TabProps {
   label: string,
   route: string,
   disabled?: boolean,
+  active?: boolean,
   subTabs?: SubTabProps[],
 }
 
@@ -29,4 +24,5 @@ export interface SubTabProps {
   label: any,
   route: string,
   disabled?: boolean,
+  active?: boolean,
 }

--- a/packages/apisuite-client-sandbox/src/containers/App/App.tsx
+++ b/packages/apisuite-client-sandbox/src/containers/App/App.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-// import { config } from 'constants/global'
 import Navigation from 'components/Navigation'
 import Footer from 'components/Footer'
 import InformDialog from 'components/InformDialog'
@@ -19,8 +18,6 @@ const App: React.FC<AppProps> = ({
   loginUser,
   logout,
 }) => {
-  const [currentTab, setCurrentTab] = React.useState(0)
-  const [currentSubTab, setCurrentSubTab] = React.useState(0)
   const [activeMenuName, setActiveMenuName] = React.useState('init')
   const [navScrolled, setNavScrolled] = React.useState(false)
   const [gobackLabel, setGobackLabel] = React.useState('')
@@ -31,12 +28,13 @@ const App: React.FC<AppProps> = ({
     login: loginTabs,
   }
   const activeMenu = allTabs[activeMenuName]
-  const subTabs = activeMenu[currentTab].subTabs
+
+  React.useEffect(function initOnce () {
+    getSettings()
+  }, [])
 
   React.useEffect(() => {
     const pathname = history.location.pathname
-
-    getSettings()
 
     if (auth.authToken && !auth.user) {
       loginUser({ token: auth.authToken })
@@ -50,10 +48,12 @@ const App: React.FC<AppProps> = ({
 
     const gb = gobackConfig.find((item) => pathname.includes(item.path))
 
-    if (pathname.startsWith('/auth') ||
-    pathname.startsWith('/confirmation') ||
-    pathname.startsWith('/registration') ||
-    pathname.startsWith('/forgot')) {
+    if (
+      pathname.startsWith('/auth') ||
+      pathname.startsWith('/confirmation') ||
+      pathname.startsWith('/registration') ||
+      pathname.startsWith('/forgot')
+    ) {
       setNavigations(false)
     } else {
       setNavigations(true)
@@ -66,78 +66,12 @@ const App: React.FC<AppProps> = ({
     }
   }, [history.location.pathname])
 
-  function handleOnTabChange (index: number) {
-    // For tabs and sub-tabs with external links
-    if (!activeMenu[index].route.startsWith('/')) {
-      window.open(activeMenu[index].route, '_blank')
-
-      return
-    }
-
-    // For tabs and sub-tabs without external links (i.e., for project navigation)
-    setCurrentTab(index)
-    setCurrentSubTab(0)
-
-    history.push(activeMenu[index].route)
-  }
-
-  function handleOnSubTabChange (index: number) {
-    const subTabs = activeMenu[currentTab].subTabs
-
-    if (Array.isArray(subTabs)) {
-      setCurrentSubTab(index)
-      history.push(subTabs[index].route)
-    }
-  }
-
   function handleGobackClick () {
     history.goBack()
   }
 
   React.useEffect(() => {
-    if (auth.user) {
-      const currentPath = history.location.pathname
-
-      /* The following code, while somewhat verbose, is required to handle
-      page refreshes, as the navigation menu misbehaves (by defaulting to
-      Dashboard - Landing page) if we don't do this path-checking. */
-      if (currentPath === '/') {
-        // Home
-        setActiveMenuName('login')
-        setCurrentTab(0)
-      } else if (currentPath === '/auth/login' || currentPath.startsWith('/dashboard')) {
-        // Setting up the aftermath of a login, that leads to Dashboard
-        if (!loginTabs[3]) {
-          return
-        }
-        setActiveMenuName('login')
-        setCurrentTab(3)
-
-        // Dashboard sub-tabs
-        if (currentPath.endsWith('/subscriptions')) {
-          setCurrentSubTab(1)
-        } else if (currentPath.endsWith('/apps')) {
-          setCurrentSubTab(2)
-        } else if (currentPath.endsWith('/test')) {
-          setCurrentSubTab(3)
-        } else {
-          setCurrentSubTab(0)
-        }
-      } else if (currentPath.startsWith('/profile')) {
-        // Profile
-        setActiveMenuName('login')
-        setCurrentTab(4)
-
-        // Profile sub-tabs
-        if (currentPath.endsWith('/team')) {
-          setCurrentSubTab(1)
-        } else if (currentPath.endsWith('/organisation')) {
-          setCurrentSubTab(2)
-        } else {
-          setCurrentSubTab(0)
-        }
-      }
-    }
+    setActiveMenuName(auth.user ? 'login' : 'init')
   }, [auth.user])
 
   return (
@@ -146,13 +80,6 @@ const App: React.FC<AppProps> = ({
         <Navigation
           key='app-navigation'
           tabs={activeMenu}
-          subTabs={Array.isArray(subTabs) ? subTabs : undefined}
-          tabIndex={currentTab}
-          subTabIndex={currentSubTab}
-          onTabChange={handleOnTabChange}
-          onSubTabChange={handleOnSubTabChange}
-          // The previous value of this property was '{config.portalName}'
-          name=''
           logoSrc={logo}
           user={auth.user}
           forceScrolled={navScrolled}


### PR DESCRIPTION
Refactored, fixed and tremendously improved the main menu.

* Simplified and reorganized menu and navigation logic.
* Kept the same menu UI to almost 100% (the font has a slightly different character spacing).
* Menu tabs now have the logic necessary to figure out themselves which menu entries are active based on the current URL (pathname). This also applies to menu entries provided by extensions.
* Changed the menus to use Material UI's Tabs element. This fixed the active menu underline and overline that did move away from the respective active menu item when the page was resized.
* Menu links are now actual links (<a>) instead of divs. We can now open links in new tabs, yay!