### PR TITLE
chore(Extensions): Upgrade CloudExtension in the Cloud env.

### DIFF
--- a/packages/apisuite-client-sandbox/extensions.cloud.json
+++ b/packages/apisuite-client-sandbox/extensions.cloud.json
@@ -1,7 +1,7 @@
 {
   "extensions": [
     {
-      "path": "github:Cloudoki/apisuite-cloud-extension-ui#v1.0.3",
+      "path": "github:Cloudoki/apisuite-cloud-extension-ui#v1.0.5",
       "name": "@apisuite/extension-cloud-extension-ui",
       "className": "CloudExtension",
       "config": {


### PR DESCRIPTION
This fixes the colliding CSS class names because the Cloud extension was bringing its own copy of the `makeStyles()` function.