### PR TITLE
fix(team-role): APIEC-211 APIEC-210

### DIFF
--- a/packages/apisuite-client-sandbox/src/containers/Auth/sagas.ts
+++ b/packages/apisuite-client-sandbox/src/containers/Auth/sagas.ts
@@ -18,7 +18,7 @@ import {
   LOGIN_PORT,
   API_URL,
 } from 'constants/endpoints'
-import { roleNameOptions } from 'containers/Profile/types'
+import { Profile } from 'containers/Profile/types'
 import qs from 'qs'
 import { openNotification } from 'containers/NotificationStack/ducks'
 
@@ -74,14 +74,20 @@ function * loginUWorker (action: AnyAction) {
     const userName = user.name.split(' ')
     const userId = user.id
 
+    const profile: Profile = yield call(request, {
+      url: `${API_URL}/users/profile`,
+      method: 'GET',
+      headers: { 'x-access-token': action.payload.token },
+    })
+
     yield put(authActions.loginUserSuccess({
       user: {
         fName: userName[0],
         lName: userName[userName.length - 1],
         id: userId,
         role: {
-          id: user.role_id,
-          name: roleNameOptions[user.role_id - 1],
+          id: profile.current_org.role.id,
+          name: profile.current_org.role.name,
         },
       },
     }))

--- a/packages/apisuite-client-sandbox/src/containers/OrganizationPage/OrganizationPage.tsx
+++ b/packages/apisuite-client-sandbox/src/containers/OrganizationPage/OrganizationPage.tsx
@@ -95,7 +95,7 @@ const OrganizationPage: React.FC<OrganizationPageProps> = ({
           <aside className={classes.aside}>
             {formState.values.logo
               // @ts-ignore This need to be fixed useForm converts the type to string|number
-              ? <img src={formState.values.logo} alt='organization logo' className={classes.img} />
+              ? <img src={formState.values.logo} alt='organisation logo' className={classes.img} />
               : <Avatar className={classes.avatar}>{initials.toLocaleUpperCase()}</Avatar>}
 
             <Button

--- a/packages/apisuite-client-sandbox/src/containers/Profile/Profile.tsx
+++ b/packages/apisuite-client-sandbox/src/containers/Profile/Profile.tsx
@@ -100,8 +100,23 @@ const Profile: React.FC<ProfileProps> = ({
     let number = parseInt(formState.values.mobileNumber)
     let org = profile.current_org.id
     if (!formState.values.mobileNumber) number = 0
-    if (option) org = option.value.toString()
-    updateProfile(formState.values.name, formState.values.bio, formState.values.avatarUrl, number, org.toString())
+    if (option && option.value) {
+      const name = profile.user.name
+      const bio = profile.user.bio ?? ''
+      const phone = Number(profile.user.mobile) ?? 0
+      const avatarUrl = profile.user.avatar ?? ''
+      org = option.value.toString()
+      updateProfile(name, bio, avatarUrl, phone, org)
+    } else {
+      updateProfile(formState.values.name, formState.values.bio, formState.values.avatarUrl, number, org.toString())
+    }
+  }
+
+  const shouldUpdateProfile = (e: React.ChangeEvent<{}>, option?: SelectOption) => {
+    e.preventDefault()
+    if (option && option.value && option.value !== profile.current_org.id) {
+      updateFormProfile(e, option)
+    }
   }
 
   return (
@@ -134,7 +149,7 @@ const Profile: React.FC<ProfileProps> = ({
             <InputLabel className={classes.inputLabel} shrink>Organisation</InputLabel>
             <Select
               options={selectOptions(profile.orgs_member)}
-              onChange={updateFormProfile}
+              onChange={shouldUpdateProfile}
               selected={selectOptions(profile.orgs_member).find(
                 option => option.value === profile.current_org.id)}
             />

--- a/packages/apisuite-client-sandbox/src/language/translations/en-US.json
+++ b/packages/apisuite-client-sandbox/src/language/translations/en-US.json
@@ -199,11 +199,11 @@
     "bio": "Bio",
     "mobileNumber": "Mobile number (international)",
     "avatarUrl": "Avatar URL",
-    "organization": "Organization",
-    "organizationDescription": "Organization description",
-    "organizationWebsite": "Organization website",
-    "organizationLogo": "Organization logo URL",
-    "organizationTerms": "Organization terms of use",
+    "organization": "Organisation",
+    "organizationDescription": "Organisation description",
+    "organizationWebsite": "Organisation website",
+    "organizationLogo": "Organisation logo URL",
+    "organizationTerms": "Organisation terms of use",
     "vat": "VAT"
   },
   "actions": {


### PR DESCRIPTION
- change organization to organisation
- fix user role by getting the role from profile on login, previously we would map the id with an array but this is prone to errors if the id doesn't match an array index
- fix requests in profile being made when the organization is cleared or set to the current value > it should only happen when the organization changes (also prevent the update of values if there're changes in the form)
- update team management by using the user's role in the team instead to the role in the user state, this way if we change the role of a user it will reflect that on page refresh and not need a logout/login

---

| Env Vars Change | Jira Ticket(s) |
| :---: | :--: |
| No | [APIEC-210](https://cloudoki.atlassian.net/browse/APIEC-210) [APIEC-211](https://cloudoki.atlassian.net/browse/APIEC-211) |
