### PR TITLE
hotfix (staging): Subscriptions modal turns white on button click

### DIFF
--- a/src/components/SubscriptionsModal/SubscriptionsModal.tsx
+++ b/src/components/SubscriptionsModal/SubscriptionsModal.tsx
@@ -332,7 +332,7 @@ const SubscriptionsModal: React.FC<SubscriptionsModalProps> = ({
 
                               <div className={classes.apiProductVersionAndSelectionContainer}>
                                 <p className={classes.apiProductVersion}>
-                                  {api.versions[0].version}
+                                  {api.versions.length !== 0 && api.versions[0].version}
                                 </p>
 
                                 {


### PR DESCRIPTION
(Hopefully) fixed an issue where the subscriptions modal turned white upon clicking the 'Review app' button.