### PR TITLE
(APIS-926) - FE: API Products page & cards missing "v" before version

### DIFF
--- a/src/components/APICatalog/APICatalog.tsx
+++ b/src/components/APICatalog/APICatalog.tsx
@@ -66,7 +66,14 @@ const APICatalog: React.FC<APICatalogProps> = ({ apisToDisplay }) => {
                 </Typography>
 
                 <Typography variant="subtitle1" gutterBottom>
-                  <Tag v={apiDetails.apiVersion} color={tagColor} />
+                  <Tag
+                    color={tagColor}
+                    v={
+                      apiDetails.apiVersion === "No version available"
+                        ? apiDetails.apiVersion
+                        : `v${apiDetails.apiVersion}`
+                    }
+                  />
                   {
                     apiDetails.apiAccess
                       ? t("sandboxPage.apiCatalog.productionAccess")

--- a/src/pages/APIProducts/APIProducts.tsx
+++ b/src/pages/APIProducts/APIProducts.tsx
@@ -72,7 +72,7 @@ export const APIProducts: React.FC = () => {
           apiName: api.apiVersions.length ? api.apiVersions[0].title : api.name,
           // Used to link an 'API Catalog' entry to its corresponding 'API Details' view.
           apiRoutingId: api.apiVersions.length ? `${api.apiVersions[0].id}` : "",
-          apiVersion: api.apiVersions.length ? `${api.apiVersions[0].version}` : "No version available",
+          apiVersion: api.apiVersions.length ? api.apiVersions[0].version : "No version available",
           hasMoreDetails: api.apiVersions.length > 0,
           id: api.apiVersions.length ? api.apiVersions[0].apiId : api.id,
         };

--- a/src/pages/APIProducts/APIProducts.tsx
+++ b/src/pages/APIProducts/APIProducts.tsx
@@ -72,7 +72,7 @@ export const APIProducts: React.FC = () => {
           apiName: api.apiVersions.length ? api.apiVersions[0].title : api.name,
           // Used to link an 'API Catalog' entry to its corresponding 'API Details' view.
           apiRoutingId: api.apiVersions.length ? `${api.apiVersions[0].id}` : "",
-          apiVersion: api.apiVersions.length ? `v${api.apiVersions[0].version}` : "No version available",
+          apiVersion: api.apiVersions.length ? `${api.apiVersions[0].version}` : "No version available",
           hasMoreDetails: api.apiVersions.length > 0,
           id: api.apiVersions.length ? api.apiVersions[0].apiId : api.id,
         };


### PR DESCRIPTION
Added 'v' prefix to versioned API Products. Need validation on the following:

- The Tag component is only used in the context of API Products (for the time being).
- Should the version verification be on the Tag component, or on the API Catalog component (as it is presently done)? The Tag component might be re-used for other things un-related to API Product versions, correct?