### PR TITLE
(APIS-899) - FE: request to 'undefined' organisation

### DIFF
--- a/src/pages/Organisation/Organisation.tsx
+++ b/src/pages/Organisation/Organisation.tsx
@@ -12,7 +12,7 @@ import { fetchOrg } from "store/profile/actions/fetchOrg";
 import { createOrg } from "store/profile/actions/createOrg";
 import { updateOrg } from "store/profile/actions/updateOrg";
 import { PageContainer } from "components/PageContainer";
-
+import { ROLES } from "constants/global";
 import { organisationSelector } from "./selector";
 import useStyles from "./styles";
 
@@ -25,7 +25,7 @@ export const Organisation: React.FC = () => {
   useEffect(() => {
     /* Triggers the retrieval and storage (on the app's Store, under 'profile > org')
     of all organisation-related information we presently have. */
-    if (auth.user?.role.id !== "5") {
+    if (auth.user?.role.id !== `${ROLES.baseUser.level}`) {
       dispatch(fetchOrg({ org_id: profile.current_org.id }));
     }
   }, [auth, dispatch, profile.current_org.id]);

--- a/src/pages/Organisation/Organisation.tsx
+++ b/src/pages/Organisation/Organisation.tsx
@@ -25,7 +25,7 @@ export const Organisation: React.FC = () => {
   useEffect(() => {
     /* Triggers the retrieval and storage (on the app's Store, under 'profile > org')
     of all organisation-related information we presently have. */
-    if (auth.user?.role.id !== `${ROLES.baseUser.level}`) {
+    if (auth.user?.role.id !== `${ROLES.baseUser.value}`) {
       dispatch(fetchOrg({ org_id: profile.current_org.id }));
     }
   }, [auth, dispatch, profile.current_org.id]);

--- a/src/pages/Organisation/Organisation.tsx
+++ b/src/pages/Organisation/Organisation.tsx
@@ -25,7 +25,7 @@ export const Organisation: React.FC = () => {
   useEffect(() => {
     /* Triggers the retrieval and storage (on the app's Store, under 'profile > org')
     of all organisation-related information we presently have. */
-    if (auth.user?.role.id !== `${ROLES.baseUser.value}`) {
+    if (auth.user?.role.name !== ROLES.baseUser.value) {
       dispatch(fetchOrg({ org_id: profile.current_org.id }));
     }
   }, [auth, dispatch, profile.current_org.id]);

--- a/src/pages/Organisation/Organisation.tsx
+++ b/src/pages/Organisation/Organisation.tsx
@@ -20,13 +20,15 @@ export const Organisation: React.FC = () => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const { t } = useTranslation();
-  const { profile, org } = useSelector(organisationSelector);
+  const { auth, profile, org } = useSelector(organisationSelector);
 
   useEffect(() => {
     /* Triggers the retrieval and storage (on the app's Store, under 'profile > org')
     of all organisation-related information we presently have. */
-    dispatch(fetchOrg({ org_id: profile.current_org.id }));
-  }, [dispatch, profile.current_org.id]);
+    if (auth.user?.role.id !== "5") {
+      dispatch(fetchOrg({ org_id: profile.current_org.id }));
+    }
+  }, [auth, dispatch, profile.current_org.id]);
 
   /*
   Organisation details

--- a/src/pages/Organisation/selector.ts
+++ b/src/pages/Organisation/selector.ts
@@ -2,8 +2,9 @@ import { createSelector } from "reselect";
 import { Store } from "store/types";
 
 export const organisationSelector = createSelector(
+  ({ auth }: Store) => auth,
   ({ profile }: Store) => profile,
-  ({ profile, org }) => {
-    return { profile, org };
+  (auth, { org, profile }) => {
+    return { auth, org, profile };
   },
 );


### PR DESCRIPTION
Made it so that org-less users don't cause an "org details" request upon visiting the "Profile -> Organisation" view.

The reasoning behind the added code was (correct if wrong):

- Admin users need to have an org upon having their own portal instance;
- Organisation owners have an org, as the name suggests;
- Developers are invited to an organisation's team;
- Base users have no organisation, and when they do, their role becomes something other than "baseUser", whose ID is different than '5'.