### PR TITLE
fix: Stopped a loop situation caused by opening an app's overlay with a specific app's ID

### DIFF
--- a/src/pages/Applications/Applications.tsx
+++ b/src/pages/Applications/Applications.tsx
@@ -20,6 +20,7 @@ import { getAllUserApps } from "store/applications/actions/getAllUserApps";
 import { getSections } from "util/extensions";
 import { applicationsSelector } from "./selector";
 import useStyles from "./styles";
+import { useParams } from "react-router-dom";
 
 export const Applications: React.FC = () => {
   const classes = useStyles();
@@ -179,18 +180,15 @@ export const Applications: React.FC = () => {
     return allUserAppCardsArray;
   };
 
+  const appIDInURL = useParams<{ appID: string }>().appID;
+
   /* The following useEffect comes in handy when users want to quickly review & edit an app
   from some other place in our project (say, from the 'API Product' subscription's modal). */
   useEffect(() => {
-    /*
-    - 'window.location.pathname' will amount to '/dashboard/apps/X'.
-    - '.split('/')[3]' will amount to 'X', our app's ID.
-    - 'parseInt()' will convert the 'X' string into a number.
-    */
-    const appIDInURL = parseInt(window.location.pathname.split("/")[3]) || undefined;
+    const parsedAppID = parseInt(appIDInURL) || undefined;
 
-    if (appIDInURL !== undefined && user) toggleModal("edit", user.id, appIDInURL);
-  }, [toggleModal, user]);
+    if (parsedAppID !== undefined && user) toggleModal("edit", user.id, parsedAppID);
+  }, []);
 
   /* Triggers the retrieval and storage (on the app's Store, under 'applications > userApps')
   of all app-related information we presently have on a particular user the first time, and


### PR DESCRIPTION
Also took the time to refactor the ID's retrieval logic, which was not using the `useParams` hook like in other places of the project.