### PR TITLE
fix: Fixed an issue related to API access requests

### DIFF
--- a/src/components/SubscriptionsModal/SubscriptionsModal.tsx
+++ b/src/components/SubscriptionsModal/SubscriptionsModal.tsx
@@ -349,7 +349,7 @@ export const SubscriptionsModal: React.FC<SubscriptionsModalProps> = ({ isModalO
                   color="primary"
                   size="large"
                   disableElevation
-                  disabled={!!selectedClientApp.subscriptions.length || !selectedClientApp.id?.toString().length}
+                  disabled={!!selectedClientApp.subscriptions.length || !selectedClientApp.id}
                   onClick={handleAPIProductAccessRequest}
                 >
                   {

--- a/src/components/SubscriptionsModal/SubscriptionsModal.tsx
+++ b/src/components/SubscriptionsModal/SubscriptionsModal.tsx
@@ -349,13 +349,11 @@ export const SubscriptionsModal: React.FC<SubscriptionsModalProps> = ({ isModalO
                   color="primary"
                   size="large"
                   disableElevation
-                  disabled={!selectedClientApp.subscriptions.length || !selectedClientApp.id?.toString().length}
+                  disabled={!!selectedClientApp.subscriptions.length || !selectedClientApp.id?.toString().length}
                   onClick={handleAPIProductAccessRequest}
                 >
                   {
-                    !selectedClientApp.id?.toString().length
-                      ? (t("dashboardTab.subscriptionsSubTab.subsModal.modalBody.buttons.requestAccess"))
-                      : (t("dashboardTab.subscriptionsSubTab.subsModal.modalBody.buttons.revokeAccess"))
+                    t("dashboardTab.subscriptionsSubTab.subsModal.modalBody.buttons.requestAccess")
                   }
                 </Button>
 

--- a/src/language/translations/en-US.json
+++ b/src/language/translations/en-US.json
@@ -276,7 +276,6 @@
           },
           "buttons": {
             "requestAccess": "Request access",
-            "revokeAccess": "Revoke access",
             "reviewOrganisation": "Review organisation",
             "reviewApp": "Review app",
             "cancel": "Cancel"


### PR DESCRIPTION
You might notice how, upon re-opening the modal after requesting access to API Products, the button is still enabled.

We are aware of this issue, and a ticket has been created for it.