### PR TITLE
feat: Retrieve website url in footer copyrights through translations

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -241,7 +241,7 @@ auth.user?.role.name === 'admin' &&
             <Typography
               variant="subtitle2"
               component="a"
-              href={t("footer.copyrights.website_url")}
+              href={t("footer.copyrights.websiteUrl")}
               rel='noopener noreferrer'
               target='_blank'
             >

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -241,7 +241,7 @@ auth.user?.role.name === 'admin' &&
             <Typography
               variant="subtitle2"
               component="a"
-              href='https://apisuite.io/'
+              href={t("footer.copyrights.website_url")}
               rel='noopener noreferrer'
               target='_blank'
             >

--- a/src/language/translations/en-US.json
+++ b/src/language/translations/en-US.json
@@ -561,7 +561,7 @@
     },
     "copyrights": {
       "website": "APISuite.io",
-      "website_url": "https://apisuite.io/",
+      "websiteUrl": "https://apisuite.io/",
       "allRightsReserved": "All rights reserved"
     }
   },

--- a/src/language/translations/en-US.json
+++ b/src/language/translations/en-US.json
@@ -561,6 +561,7 @@
     },
     "copyrights": {
       "website": "APISuite.io",
+      "website_url": "https://apisuite.io/",
       "allRightsReserved": "All rights reserved"
     }
   },


### PR DESCRIPTION
In the current implementation of the frontend, the copyright link in the footer is hardcoded to point to the APISuite. In order to cope with a custom url (which could be different depending on the language), a small change to the code has been implemented to load the website URL through the portal's translations. By default, it will still redirect to the APISuite.