### PR TITLE
feat: Show policies in footer

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -157,6 +157,39 @@ const SubSection = ({ subMenu, roleName }: { subMenu: string; roleName?: string 
   );
 };
 
+const Policy = ({name}: {name: string}) => {
+  const [t] = useTranslation();
+  const classes = useStyles();
+  return (
+    <Typography
+      variant="subtitle2"
+      component="a"
+      href={t(`footer.policies.${name}.url`)}
+      className={classes.policy}
+    >
+      {t(`footer.policies.${name}.text`)}
+    </Typography>
+  );
+};
+
+const doesPolicyExist = (t: (key: string) => string, name: string): boolean => {
+  const urlTrans = `footer.policies.${name}.url`;
+  return t(urlTrans) !== urlTrans && t(urlTrans) !== "";
+};
+
+const Policies = () => {
+  const [t] = useTranslation();
+  const policies = ["termsOfUse", "privacy", "cookie"];
+  return (
+    <>
+      {
+        policies.map((p: string) =>  doesPolicyExist(t, p) && (<Policy name={p}/>) )
+      }
+    </>
+  );
+};
+
+
 // Footer
 
 const Footer: React.FC<FooterProps> = (
@@ -247,8 +280,8 @@ auth.user?.role.name === 'admin' &&
             >
               &copy; {new Date().getFullYear()} {t("footer.copyrights.website")}
             </Typography>
-
             <Typography variant="subtitle2">{t("footer.copyrights.allRightsReserved")}</Typography>
+            <Policies />
           </div>
 
           <LocaleSelect />

--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -78,7 +78,7 @@ export default makeStyles((theme) => ({
     display: "flex",
     flexFlow: "wrap",
     justifyContent: "left",
-    maxWidth: "700px",
+    maxWidth: "600px",
     width: "100%",
   },
 
@@ -103,7 +103,7 @@ export default makeStyles((theme) => ({
     display: "flex",
     flexFlow: "wrap",
     justifyContent: "flex-end",
-    maxWidth: "180px",
+    maxWidth: "280px",
     width: "100%",
   },
 
@@ -127,6 +127,13 @@ export default makeStyles((theme) => ({
     textDecoration: "none",
     "&:link, &:visited, &:hover, &:active": {
       color: "inherit",
+    },
+  },
+
+  policy: {
+    marginRight: ".25rem",
+    "&:last-child": {
+      marginRight: 0,
     },
   },
 }));

--- a/src/language/translations/en-US.json
+++ b/src/language/translations/en-US.json
@@ -562,6 +562,20 @@
     "copyrights": {
       "website": "APISuite.io",
       "allRightsReserved": "All rights reserved"
+    },
+    "policies": {
+      "termsOfUse": {
+        "text": "Terms of use",
+        "url": ""
+      },
+      "privacy": {
+        "text": "Privacy policy",
+        "url": ""
+      },
+      "cookie": {
+        "text": "Cookie policy",
+        "url": ""
+      }
     }
   },
   "listApps": {


### PR DESCRIPTION
In the current implementation of the marketplace, there seems to be no way to show the policies (terms of use, privacy policy, cookie policy) on the main page. This  is important information and is required in order to get accepted by some payment gateways (such as Mollie). A piece of code was added that dynamically loads policy links based on the translations. It will check if the portal has a URL defined for the following translation keys:

- footer.policies.termsOfUse
- footer.policies.privacy
- footer.policies.cookie

If this is the case, it will show the URL and the corresponding label right beneath "All rights reserved" on the portal. This means the user always has access to the necessary policies.