### PR TITLE
fix(TeamPage): wrong role actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apisuite-fe",
-  "version": "1.25.3",
+  "version": "1.26.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "apisuite-fe",
-      "version": "1.25.3",
+      "version": "1.26.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@apisuite/fe-base": "1.0.0-next.10",
@@ -108,6 +108,78 @@
       },
       "optionalDependencies": {
         "cypress": "7.2.0"
+      }
+    },
+    "../apisuite-cloud-extension-ui/dev-symlink-target": {
+      "name": "@apisuite/extension-cloud-extension-ui",
+      "version": "1.12.9",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/core": "10.0.0",
+        "react-dropzone": "11.2.4"
+      },
+      "devDependencies": {
+        "@apisuite/extension-ui-types": "1.0.5",
+        "@apisuite/fe-base": "1.0.0-next.10",
+        "@babel/core": "7.11.4",
+        "@material-ui/icons": "4.5.1",
+        "@material-ui/lab": "4.0.0-alpha.56",
+        "@semantic-release/git": "^9.0.0",
+        "@testing-library/jest-dom": "5.11.4",
+        "@testing-library/react": "10.4.9",
+        "@types/jest": "26.0.10",
+        "@types/react": "17.0.2",
+        "@types/react-dom": "17.0.2",
+        "@types/react-redux": "7.1.16",
+        "@typescript-eslint/eslint-plugin": "3.10.1",
+        "@typescript-eslint/parser": "3.10.1",
+        "babel-loader": "8.1.0",
+        "babel-preset-react-app": "9.1.2",
+        "eslint": "7.7.0",
+        "eslint-config-prettier": "6.11.0",
+        "eslint-plugin-import": "2.22.0",
+        "eslint-plugin-jest": "23.20.0",
+        "eslint-plugin-jsx-a11y": "6.3.1",
+        "eslint-plugin-prettier": "3.1.4",
+        "eslint-plugin-react": "7.20.6",
+        "eslint-plugin-react-hooks": "4.1.0",
+        "formik": "2.2.0",
+        "identity-obj-proxy": "3.0.0",
+        "immutability-helper": "3.1.1",
+        "jest": "26.4.2",
+        "lint-staged": "10.2.12",
+        "npm-watch": "0.9.0",
+        "prettier": "2.1.0",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
+        "react-redux": "7.1.3",
+        "react-router": "5.1.2",
+        "react-router-dom": "5.1.2",
+        "redux": "4.0.4",
+        "redux-saga": "1.1.3",
+        "reselect": "4.0.0",
+        "sass-loader": "10.0.1",
+        "semantic-release": "^17.4.4",
+        "ts-jest": "26.2.0",
+        "typescript": "4.2.4",
+        "yup": "0.29.3"
+      },
+      "peerDependencies": {
+        "@apisuite/fe-base": "1.0.0-next.10",
+        "@material-ui/icons": ">=4.5.1",
+        "@material-ui/lab": ">=4.0.0-alpha.56",
+        "formik": ">=2.2.0",
+        "immutability-helper": ">=3.1.1",
+        "react": ">=17.0.2",
+        "react-dom": ">=17.0.2",
+        "react-redux": ">=7.2.4",
+        "react-router": ">=5.1.2",
+        "react-router-dom": ">=5.1.2",
+        "redux": ">=4.0.4",
+        "redux-saga": ">=1.1.3",
+        "reselect": ">=4.0.0",
+        "yup": ">=0.29.3"
       }
     },
     "node_modules/@apisuite/extension-ui-types": {

--- a/src/components/ApplicationsModal/ApplicationsModal.tsx
+++ b/src/components/ApplicationsModal/ApplicationsModal.tsx
@@ -275,7 +275,7 @@ export const ApplicationsModal: React.FC<ApplicationsModalProps> = ({
     if (modalMode === "edit") {
       reset({
         appAvatarURL: mostRecentlySelectedAppDetails.logo ?? "",
-        appClientID: mostRecentlySelectedAppDetails.clientId ?? "",
+        appClientID: mostRecentlySelectedAppDetails.clientId?.toString() ?? "",
         appClientSecret: mostRecentlySelectedAppDetails.clientSecret ?? "",
         appDirectURL: mostRecentlySelectedAppDetails.directUrl ?? "",
         appDescription: mostRecentlySelectedAppDetails.description ?? "",

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -19,9 +19,7 @@ export const Navigation: React.FC<NavigationProps> = ({ contractible = false, cl
   const { t } = useTranslation();
   const { user, currentOrg } = useSelector(navigationSelector);
   // FIXME: checking the id because profile is never undefined
-  console.log({ currentOrg, user });
   const role = currentOrg?.role?.id > -1 ? currentOrg.role.name : user.id > -1 ? ROLES.baseUser.value : "anonymous";
-  console.log({ role });
 
   const [isMaxWidth, setIsMaxWidth] = useState(window.innerWidth <= 1024);
 

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -19,7 +19,9 @@ export const Navigation: React.FC<NavigationProps> = ({ contractible = false, cl
   const { t } = useTranslation();
   const { user, currentOrg } = useSelector(navigationSelector);
   // FIXME: checking the id because profile is never undefined
-  const role = currentOrg?.role?.id ? currentOrg.role.name : user.id ? ROLES.baseUser.value : "anonymous";
+  console.log({ currentOrg, user });
+  const role = currentOrg?.role?.id > -1 ? currentOrg.role.name : user.id > -1 ? ROLES.baseUser.value : "anonymous";
+  console.log({ role });
 
   const [isMaxWidth, setIsMaxWidth] = useState(window.innerWidth <= 1024);
 

--- a/src/components/SubbedAppsBlock/types.d.ts
+++ b/src/components/SubbedAppsBlock/types.d.ts
@@ -9,7 +9,7 @@ export type UserDetails = {
   avatar?: string,
   bio?: string,
   email: string,
-  id: string,
+  id: number,
   "last_login": string,
   mobile?: string,
   name: string,

--- a/src/components/SubscriptionsModal/SubscriptionsModal.tsx
+++ b/src/components/SubscriptionsModal/SubscriptionsModal.tsx
@@ -37,10 +37,10 @@ export const SubscriptionsModal: React.FC<SubscriptionsModalProps> = ({ appID, i
     clientSecret: "",
     createdAt: "",
     description: "",
-    id: "",
+    id: -1,
     logo: "",
     name: "",
-    orgId: "",
+    orgId: -1,
     privacyUrl: "",
     redirectUrl: "",
     summary: "",
@@ -165,7 +165,7 @@ export const SubscriptionsModal: React.FC<SubscriptionsModalProps> = ({ appID, i
                   displayEmpty
                   IconComponent={ExpandMoreRoundedIcon}
                   value={
-                    selectedClientApp.id === ""
+                    selectedClientApp.id < 0
                       ? ""
                       : selectedClientApp.name
                   }

--- a/src/pages/Applications/Applications.tsx
+++ b/src/pages/Applications/Applications.tsx
@@ -37,7 +37,7 @@ export const Applications: React.FC = () => {
   const [hasCurrentOrgDetails, setHasCurrentOrgDetails] = useState(false);
 
   const isOrg = (_org: Organization | Organization & { member_since: string; role: Role }) => {
-    return Object.keys(_org).length !== 0 && _org.id !== "";
+    return Object.keys(_org).length !== 0 && _org.id > 0;
   };
 
   /* With every change of our store's 'profile > profile > currentOrg' section
@@ -181,7 +181,7 @@ export const Applications: React.FC = () => {
     const parsedAppID = parseInt(appIDInURL) || undefined;
 
     if (parsedAppID !== undefined && user) toggleModal("edit", user.id, parsedAppID);
-  }, []);
+  }, [appIDInURL, user, toggleModal]);
 
   /* Triggers the retrieval and storage (on the app's Store, under 'applications > userApps')
   of all app-related information we presently have on a particular user the first time, and

--- a/src/pages/Organisation/Organisation.tsx
+++ b/src/pages/Organisation/Organisation.tsx
@@ -33,7 +33,7 @@ export const Organisation: React.FC = () => {
 
   /*
   Organisation details
-  
+
   Note:
   - 'formState' refers to our own, local copy of a organisation's details.
   - 'org' refers to our stored, back-end approved copy of a user's organisation details (under 'profile > org').
@@ -207,7 +207,7 @@ export const Organisation: React.FC = () => {
   const updateOrgDetails = (event: React.ChangeEvent<any>) => {
     event.preventDefault();
 
-    const orgId = org.id.toString();
+    const orgId = org.id;
 
     const orgInfo = {
       name: formState.values.orgName,

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -165,7 +165,7 @@ export const Profile: React.FC = () => {
     role: {
       id: -1,
       name: ROLES.baseUser.value,
-      level: 1000,
+      level: ROLES.baseUser.level,
     },
   });
 

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -7,7 +7,7 @@ import ExpandLessRoundedIcon from "@material-ui/icons/ExpandLessRounded";
 import ExpandMoreRoundedIcon from "@material-ui/icons/ExpandMoreRounded";
 import ImageSearchRoundedIcon from "@material-ui/icons/ImageSearchRounded";
 
-import { LOCAL_STORAGE_KEYS, ROLES } from "constants/global";
+import { ROLES } from "constants/global";
 import { deleteAccount } from "store/profile/actions/deleteAccount";
 import { getProfile } from "store/profile/actions/getProfile";
 import { getRoleName, getSSOAccountURLSelector, profileSelector } from "./selectors";
@@ -25,7 +25,6 @@ import Notice from "components/Notice";
 import Link from "components/Link";
 import { PageContainer } from "components/PageContainer";
 import { testIds } from "testIds";
-import { setInStorage } from "util/localStorageActions";
 
 export const Profile: React.FC = () => {
   const classes = useStyles();
@@ -164,8 +163,9 @@ export const Profile: React.FC = () => {
     label: "",
     value: "",
     role: {
-      id: "",
+      id: -1,
       name: ROLES.baseUser.value,
+      level: 1000,
     },
   });
 
@@ -197,23 +197,21 @@ export const Profile: React.FC = () => {
     if (
       currentlySelectedOrganisation &&
       currentlySelectedOrganisation.value &&
-      currentlySelectedOrganisation.value !== profile.currentOrg.id
+      Number(currentlySelectedOrganisation.value) !== profile.currentOrg.id
     ) {
       const newOrg = {
-        id: currentlySelectedOrganisation.value,
+        id: Number(currentlySelectedOrganisation.value),
         name: currentlySelectedOrganisation.label,
         role: currentlySelectedOrganisation.role,
       };
 
-      setInStorage(LOCAL_STORAGE_KEYS.STORED_ORG, newOrg);
-      
       dispatch(switchOrg({ newOrg }));
     }
   };
 
   useEffect(() => {
     // Once our store's 'profile' details load, we check if there's organisation data associated to it
-    const hasOrgDetails = Object.keys(profile.currentOrg).length !== 0 && profile.currentOrg.id !== "";
+    const hasOrgDetails = Object.keys(profile.currentOrg).length !== 0 && profile.currentOrg.id > 0;
 
     setProfileHasOrgDetails(hasOrgDetails);
   }, [profile]);
@@ -223,7 +221,7 @@ export const Profile: React.FC = () => {
     setCurrentlySelectedOrganisation({
       group: "",
       label: profile.currentOrg.name,
-      value: profile.currentOrg.id,
+      value: profile.currentOrg.id.toString(),
       role: profile.currentOrg.role,
     });
   }, [profile]);
@@ -381,7 +379,7 @@ export const Profile: React.FC = () => {
                     organisationSelector(profile.organizations).find((selectedOrganisation) => {
                       return currentlySelectedOrganisation.value === ""
                         ? (selectedOrganisation.value === profile.currentOrg.id)
-                        : (selectedOrganisation.value === currentlySelectedOrganisation.value);
+                        : (selectedOrganisation.value === Number(currentlySelectedOrganisation.value));
                     })
                   }
                 />
@@ -389,7 +387,7 @@ export const Profile: React.FC = () => {
                 <Box clone mt={3}>
                   <Button
                     data-test-id={testIds.profileOverviewSelectorButton}
-                    disabled={currentlySelectedOrganisation.value === profile.currentOrg.id}
+                    disabled={Number(currentlySelectedOrganisation.value) === profile.currentOrg.id}
                     size="large"
                     color="primary"
                     variant="contained"

--- a/src/pages/TeamPage/TeamPage.tsx
+++ b/src/pages/TeamPage/TeamPage.tsx
@@ -405,7 +405,7 @@ export const TeamPage: React.FC = () => {
           setRemoveUserDialogOpen(false);
           setIdOfMemberToRemove("");
         }}
-        confirmButtonCallback={() => removeFromTeam(currentOrganisation.id, user!.id, Number(idOfMemberToRemove))}
+        confirmButtonCallback={() => removeFromTeam(currentOrganisation.id, user.id, Number(idOfMemberToRemove))}
         confirmButtonLabel={t("rbac.team.dialogs.removeUser.confirmButtonLabel")}
         confirmButtonStyle={classes.deleteAppButtonStyles}
         open={removeUserDialogOpen}

--- a/src/pages/TeamPage/TeamPage.tsx
+++ b/src/pages/TeamPage/TeamPage.tsx
@@ -405,7 +405,9 @@ export const TeamPage: React.FC = () => {
           setRemoveUserDialogOpen(false);
           setIdOfMemberToRemove("");
         }}
-        confirmButtonCallback={() => removeFromTeam(currentOrganisation.id, user.id, Number(idOfMemberToRemove))}
+        confirmButtonCallback={
+          () => user && removeFromTeam(currentOrganisation.id, user.id, Number(idOfMemberToRemove))
+        }
         confirmButtonLabel={t("rbac.team.dialogs.removeUser.confirmButtonLabel")}
         confirmButtonStyle={classes.deleteAppButtonStyles}
         open={removeUserDialogOpen}

--- a/src/pages/TeamPage/TeamPage.tsx
+++ b/src/pages/TeamPage/TeamPage.tsx
@@ -226,20 +226,20 @@ export const TeamPage: React.FC = () => {
     const role = getUserMemberRole(currentUser);
 
     // only organization owner and up can remove users if sibling or under levels
-    if (role.level > 3 || role.level > providedMember.Role.level) {
+    if (role.level > ROLES.organizationOwner.level || role.level > providedMember.Role.level) {
       return false;
     }
 
     // admins can't remove itself
-    if (role.level < 3 && currentUser.id === providedMember.User.id) {
+    if (role.level <= ROLES.admin.level && currentUser.id === providedMember.User.id) {
       return false;
     }
 
     // if the member to remove is organization owner and up, at least one more sibling or parent level should exist
     // in team members array
-    if (providedMember.Role.level < 4) {
+    if (providedMember.Role.level <= ROLES.organizationOwner.level) {
       // our user is also present in the team members array
-      return teamMembers.filter((member) => member.Role.level < 4).length > 1;
+      return teamMembers.filter((member) => member.Role.level <= ROLES.organizationOwner.level).length > 1;
     }
 
     // we can remove every other case

--- a/src/pages/TeamPage/TeamPage.tsx
+++ b/src/pages/TeamPage/TeamPage.tsx
@@ -32,7 +32,7 @@ export const TeamPage: React.FC = () => {
   const { currentOrganisation, members, requestStatuses, roleOptions, user } = useSelector(teamPageSelector);
 
   useEffect(() => {
-    if (currentOrganisation.id !== "") {
+    if (currentOrganisation.id > 0) {
       dispatch(fetchTeamMembers({}));
       dispatch(fetchRoleOptions({}));
     }
@@ -48,10 +48,12 @@ export const TeamPage: React.FC = () => {
   const changeRoleDisabled = (m: FetchTeamMembersResponse) => {
     if (!user) return true;
 
+    const role = getUserMemberRole(user);
+
     return (
-      getUserMemberRole(user).name === ROLES.developer.value ||
+      role.level < ROLES.developer.level,
       user.id === m.User.id ||
-      ROLES[getUserMemberRole(user).name].level > ROLES[m.Role.name].level
+      role.level > m.Role.level
     );
   };
 
@@ -59,6 +61,7 @@ export const TeamPage: React.FC = () => {
     return roles.map(role => ({
       label: ROLES[role.name]?.label,
       value: role.id,
+      level: role.level,
       group: "Role",
     })).filter((role) => role.label !== ROLES.baseUser.label);
   };
@@ -70,7 +73,7 @@ export const TeamPage: React.FC = () => {
     });
   }
 
-  const handleChangeRole = (userId: string, orgId: string) => ({ target }: React.ChangeEvent<any>) => {
+  const handleChangeRole = (userId: number, orgId: number) => ({ target }: React.ChangeEvent<any>) => {
     // TODO: review; there's is something wrongly typed somewhere
     if (target.value) {
       dispatch(changeRole({
@@ -118,7 +121,7 @@ export const TeamPage: React.FC = () => {
         dispatch(inviteTeamMember({
           email: input.email,
           orgID: currentOrganisation.id,
-          role_id: input.roleId.toString(),
+          role_id: Number(input.roleId),
         }));
       }}
     >
@@ -149,7 +152,15 @@ export const TeamPage: React.FC = () => {
           value={input.roleId}
           variant="outlined"
         >
-          {selectOptions(roleOptions).map((opt) => <MenuItem key={opt.value} value={opt.value}>{opt.label}</MenuItem>)}
+          {selectOptions(roleOptions).map((opt) => (
+            <MenuItem
+              key={opt.value}
+              value={opt.value}
+              disabled={opt.level < (user?.role.level ?? -1)}
+            >
+              {opt.label}
+            </MenuItem>
+          ))}
         </Select>
       </Box>
 
@@ -212,35 +223,36 @@ export const TeamPage: React.FC = () => {
   ) => {
     if (!currentUser) return false;
 
-    const membersWithSameRole: FetchTeamMembersResponse[] = teamMembers.filter(
-      (teamMember: FetchTeamMembersResponse) => {
-        return currentUser.id !== teamMember.User.id && teamMember.Role.name === getUserMemberRole(currentUser).name;
-      }
-    );
+    const role = getUserMemberRole(currentUser);
 
-    if (currentUser.id === providedMember.User.id) {
-      if (AUTHORIZED_ROLES.includes(getUserMemberRole(currentUser).name) && membersWithSameRole.length) return true;
-
-      if (getUserMemberRole(currentUser).name === ROLES.developer.value) return true;
+    // only organization owner and up can remove users if sibling or under levels
+    if (role.level > 3 || role.level > providedMember.Role.level) {
+      return false;
     }
 
-    if (
-      ROLES[getUserMemberRole(currentUser).name].level <= ROLES[providedMember.Role.name].level &&
-      getUserMemberRole(currentUser).name !== ROLES.developer.value
-    ) {
-      return true;
+    // admins can't remove itself
+    if (role.level < 3 && currentUser.id === providedMember.User.id) {
+      return false;
     }
 
-    return false;
+    // if the member to remove is organization owner and up, at least one more sibling or parent level should exist
+    // in team members array
+    if (providedMember.Role.level < 4) {
+      // our user is also present in the team members array
+      return teamMembers.filter((member) => member.Role.level < 4).length > 1;
+    }
+
+    // we can remove every other case
+    return true;
   };
 
   const [removeUserDialogOpen, setRemoveUserDialogOpen] = useState(false);
   const [idOfMemberToRemove, setIdOfMemberToRemove] = useState("");
 
   const removeFromTeam = (
-    orgID: string,
-    idOfCurrentUser: string,
-    idOfUserToRemove: string,
+    orgID: number,
+    idOfCurrentUser: number,
+    idOfUserToRemove: number,
   ) => {
     setRemoveUserDialogOpen(false);
 
@@ -297,7 +309,7 @@ export const TeamPage: React.FC = () => {
                     {members.map((member) => (
                       <TableRow className={classes.tableRow} key={member.User.id}>
                         <TableCell scope="row" style={{ paddingLeft: spacing(5) }}>
-                          {member.User.name}
+                          {member.User.name} {member.User.id === user?.id ? "(me)" : ""}
 
                           <br />
 
@@ -315,9 +327,17 @@ export const TeamPage: React.FC = () => {
                             value={member.Role.id}
                             variant="outlined"
                           >
-                            {selectOptions(roleOptions).map((opt) => (
-                              <MenuItem key={opt.value} value={opt.value}>{opt.label}</MenuItem>
-                            ))}
+                            {selectOptions(roleOptions).map((opt) => {
+                              return (
+                                <MenuItem
+                                  key={opt.value}
+                                  value={opt.value}
+                                  disabled={opt.level < (user?.role.level ?? -1)}
+                                >
+                                  {opt.label}
+                                </MenuItem>
+                              );
+                            })}
                           </Select>
                         </TableCell>
 
@@ -385,7 +405,7 @@ export const TeamPage: React.FC = () => {
           setRemoveUserDialogOpen(false);
           setIdOfMemberToRemove("");
         }}
-        confirmButtonCallback={() => removeFromTeam(currentOrganisation.id, user!.id.toString(), idOfMemberToRemove)}
+        confirmButtonCallback={() => removeFromTeam(currentOrganisation.id, user!.id, Number(idOfMemberToRemove))}
         confirmButtonLabel={t("rbac.team.dialogs.removeUser.confirmButtonLabel")}
         confirmButtonStyle={classes.deleteAppButtonStyles}
         open={removeUserDialogOpen}

--- a/src/store/applications/actions/types.d.ts
+++ b/src/store/applications/actions/types.d.ts
@@ -36,7 +36,7 @@ DeleteAppMediaActionError
 
 export type CreateAppAction = {
   type: typeof CREATE_APP,
-  orgID: string,
+  orgID: number,
   appData: CreateAppActionData,
 }
 
@@ -50,7 +50,7 @@ export type CreateAppActionError = {
 
 export type UpdateAppAction = {
   type: typeof UPDATE_APP,
-  orgID: string,
+  orgID: number,
   appData: UpdateAppActionData,
 }
 
@@ -66,7 +66,7 @@ export type UpdateAppActionError = {
 export type DeleteAppAction = {
   type: typeof DELETE_APP,
   appId: number,
-  orgID: string,
+  orgID: number,
 }
 
 export type DeleteAppActionSuccess = {
@@ -79,7 +79,7 @@ export type DeleteAppActionError = {
 
 export type RequestAPIAccessAction = {
   type: typeof REQUEST_API_ACCESS,
-  orgID: string,
+  orgID: number,
   appId: number,
 }
 
@@ -93,7 +93,7 @@ export type RequestAPIAccessActionError = {
 
 export type GetUserAppAction = {
   type: typeof GET_USER_APP,
-  orgID: string,
+  orgID: number,
   appId: number,
 }
 
@@ -108,7 +108,7 @@ export type GetUserAppActionError = {
 
 export type GetAllUserAppsAction = {
   type: typeof GET_ALL_USER_APPS,
-  orgID: string,
+  orgID: number,
 }
 
 export type GetAllUserAppsActionSuccess = {
@@ -123,7 +123,7 @@ export type GetAllUserAppsActionError = {
 
 export type UploadAppMediaAction = {
   type: typeof UPLOAD_APP_MEDIA,
-  orgID: string,
+  orgID: number,
   appId: number,
   media: FormData,
 }
@@ -140,7 +140,7 @@ export type UploadAppMediaActionError = {
 
 export type DeleteAppMediaAction = {
   type: typeof DELETE_APP_MEDIA,
-  orgID: string,
+  orgID: number,
   appId: number,
   media: string,
 }

--- a/src/store/applications/reducer.ts
+++ b/src/store/applications/reducer.ts
@@ -14,7 +14,7 @@ import { DELETE_APP_MEDIA_SUCCESS } from "./actions/deleteAppMedia";
 /** Initial state */
 const initialState: ApplicationsStore = {
   currentApp: {
-    clientId: "",
+    clientId: -1,
     clientSecret: "",
     createdAt: "",
     description: "",
@@ -24,7 +24,7 @@ const initialState: ApplicationsStore = {
     logo: "",
     metadata: [],
     name: "",
-    orgId: "",
+    orgId: -1,
     privacyUrl: "",
     redirectUrl: "",
     summary: "",

--- a/src/store/applications/types.d.ts
+++ b/src/store/applications/types.d.ts
@@ -16,7 +16,7 @@ export interface ApplicationsStore {
 }
 
 export interface AppData {
-  clientId: string,
+  clientId: number,
   clientSecret: string,
   createdAt: string,
   description: string,
@@ -25,7 +25,7 @@ export interface AppData {
   labels: string[],
   logo: string,
   name: string,
-  orgId: string,
+  orgId: number,
   privacyUrl: string,
   redirectUrl: string,
   summary: string,
@@ -65,7 +65,7 @@ export interface ApplicationsProps {
   },
   createAppStatus: boolean,
   deleteAppStatus: boolean,
-  getAllUserAppsAction: (orgID: string) => void,
+  getAllUserAppsAction: (orgID: number) => void,
   requestAPIAccessStatus: boolean,
   updateAppStatus: boolean,
   user: User,

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -114,7 +114,7 @@ function * loginUserWorker () {
     let org = profile.organizations[0];
 
     if (orgId) {
-      const orgFound = profile.organizations.find((org) => org.id === Number(orgId));
+      const orgFound = profile.organizations.find((organization) => organization.id === Number(orgId));
       if (orgFound) {
         org = orgFound;
       }

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -143,7 +143,7 @@ function * loginUserWorker () {
         role: {
           id: org.role?.id ?? -1,
           name: org.role?.name ?? ROLES.baseUser.value,
-          level: org.role?.level ?? 1000,
+          level: org.role?.level ?? ROLES.baseUser.level,
         },
       },
     }));

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -65,6 +65,7 @@ import {
 
 import { Invitation } from "./types";
 import { getReCAPTCHAToken, ReCaptchaActions } from "util/getReCAPTCHAToken";
+import { getSelectedOrganization } from "util/getSelectedOrganization";
 
 function * loginWorker (action: LoginAction) {
   try {
@@ -110,30 +111,7 @@ function * loginUserWorker () {
       localStorage.setItem(LOCAL_STORAGE_KEYS.CURRENT_USER, user.id.toString());
     }
 
-    const orgId = localStorage.getItem(LOCAL_STORAGE_KEYS.STORED_ORG);
-    let org = profile.organizations[0];
-
-    if (orgId) {
-      const orgFound = profile.organizations.find((organization) => organization.id === Number(orgId));
-      if (orgFound) {
-        org = orgFound;
-      }
-    }
-
-    if (!org) {
-      // review this - should we really keep an empty organization?
-      org = {
-        id: -1,
-        name: "",
-        role: {
-          id: -1,
-          name: ROLES.baseUser.value,
-          level: ROLES.baseUser.level,
-        },
-      };
-    }
-
-    localStorage.setItem(LOCAL_STORAGE_KEYS.STORED_ORG, org.id.toString());
+    const org = getSelectedOrganization(profile.organizations);
 
     // TODO: better types for this response
     const settings: { navigation: DefaultConfig["navigation"] } = yield call(request, {

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -121,7 +121,7 @@ function * loginUserWorker () {
     }
 
     if (!org) {
-      // TODO: review this - should we really keep an empty organization?
+      // FIXME: review this - should we really keep an empty organization?
       org = {
         id: -1,
         name: "",

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -121,7 +121,16 @@ function * loginUserWorker () {
     }
 
     if (!org) {
-      throw new Error("profile has no organizations");
+      // TODO: review this - should we really keep an empty organization?
+      org = {
+        id: -1,
+        name: "",
+        role: {
+          id: -1,
+          name: ROLES.baseUser.value,
+          level: ROLES.baseUser.level,
+        },
+      };
     }
 
     localStorage.setItem(LOCAL_STORAGE_KEYS.STORED_ORG, org.id.toString());

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -149,11 +149,7 @@ function * loginUserWorker () {
         fName: userName[0],
         lName: userName[userName.length - 1],
         id: user.id,
-        role: {
-          id: org.role?.id ?? -1,
-          name: org.role?.name ?? ROLES.baseUser.value,
-          level: org.role?.level ?? ROLES.baseUser.level,
-        },
+        role: {...org.role},
       },
     }));
   } catch (error) {

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -121,7 +121,7 @@ function * loginUserWorker () {
     }
 
     if (!org) {
-      // FIXME: review this - should we really keep an empty organization?
+      // review this - should we really keep an empty organization?
       org = {
         id: -1,
         name: "",

--- a/src/store/auth/types.d.ts
+++ b/src/store/auth/types.d.ts
@@ -1,4 +1,4 @@
-import { OrganizationAndRole } from "store/profile/types";
+import { OrganizationAndRole, Role } from "store/profile/types";
 
 export interface AuthStore {
   authToken?: string,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,6 +9,7 @@ import loggerMiddleware from "redux-logger";
 import { composeWithDevTools } from "redux-devtools-extension";
 import { createAuthMiddleware } from "store/auth/middleware";
 import { createApplicationsMiddleware } from "store/applications/middleware";
+import { createProfileMiddleware } from "./profile/middleware";
 
 import combinedReducers from "./combinedReducers";
 import combinedSagas from "./combinedSagas";
@@ -22,8 +23,9 @@ let injectedSagas: any = [];
 const sagaMiddleware = createSagaMiddleware();
 const authMiddleware = createAuthMiddleware(history);
 const applicationsMiddleware = createApplicationsMiddleware(history);
+const profileMiddleware = createProfileMiddleware();
 
-const middleware = [sagaMiddleware, authMiddleware, applicationsMiddleware];
+const middleware = [sagaMiddleware, authMiddleware, applicationsMiddleware, profileMiddleware];
 
 let composedMiddleware;
 

--- a/src/store/markdownPages/types.d.ts
+++ b/src/store/markdownPages/types.d.ts
@@ -1,5 +1,5 @@
 export type GetMarkdownPageResponse = {
-  id: string,
+  id: number,
   locale: string,
   content: string,
   updatedAt: string,

--- a/src/store/profile/actions/types.d.ts
+++ b/src/store/profile/actions/types.d.ts
@@ -58,9 +58,9 @@ export type ProfileActions =
 
 export type ChangeRoleAction = {
   type: typeof CHANGE_ROLE,
-  "user_id": string,
-  "org_id": string,
-  "role_id": string,
+  "user_id": number,
+  "org_id": number,
+  "role_id": number,
 }
 
 export type ChangeRoleActionSuccess = {
@@ -116,7 +116,7 @@ export type DeleteAccountActionError = {
 
 export type FetchOrgAction = {
   type: typeof FETCH_ORG,
-  "org_id": string,
+  org_id: number,
 }
 
 export type FetchOrgActionSuccess = {
@@ -174,9 +174,9 @@ export type GetProfileActionError = {
 
 export type InviteTeamMemberAction = {
   type: typeof INVITE_TEAM_MEMBER,
-  orgID: string,
+  orgID: number,
   email: string,
-  "role_id": string,
+  role_id: number,
 }
 
 export type InviteTeamMemberActionSuccess = {
@@ -190,9 +190,9 @@ export type InviteTeamMemberActionError = {
 
 export type RemoveTeamMemberAction = {
   type: typeof REMOVE_TEAM_MEMBER,
-  orgID: string,
-  idOfCurrentUser: string,
-  idOfUserToRemove: string,
+  orgID: number,
+  idOfCurrentUser: number,
+  idOfUserToRemove: number,
 }
 
 export type RemoveTeamMemberActionSuccess = {
@@ -224,7 +224,7 @@ export type SwitchOrgActionError = {
 
 export type UpdateOrgAction = {
   type: typeof UPDATE_ORG,
-  orgId: string,
+  orgId: number,
   orgInfo: ExistingOrgInfo,
 }
 
@@ -240,7 +240,7 @@ export type UpdateOrgActionError = {
 
 export type UpdateProfileAction = {
   type: typeof UPDATE_PROFILE,
-  userId: string,
+  userId: number,
   name: string,
   bio: string,
   avatar: string,

--- a/src/store/profile/middleware.ts
+++ b/src/store/profile/middleware.ts
@@ -1,0 +1,16 @@
+import { AnyAction, Dispatch } from "redux";
+import { LOCAL_STORAGE_KEYS } from "constants/global";
+import { SWITCH_ORG } from "./actions/switchOrg";
+import { SwitchOrgAction } from "./actions/types";
+
+export const createProfileMiddleware = () => () => (next: Dispatch) => (action: AnyAction) => {
+  next(action);
+
+  if (action.type === SWITCH_ORG) {
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEYS.STORED_ORG, (action as SwitchOrgAction).newOrg.id.toString());
+    } catch (error) {
+      // ignore
+    }
+  }
+};

--- a/src/store/profile/reducer.ts
+++ b/src/store/profile/reducer.ts
@@ -32,7 +32,7 @@ const initialState: ProfileStore = {
     Role: {
       id: -1,
       name: ROLES.baseUser.value,
-      level: 1000,
+      level: ROLES.baseUser.level,
     },
   }],
   profile: {
@@ -42,7 +42,7 @@ const initialState: ProfileStore = {
       role: {
         id: -1,
         name: ROLES.baseUser.value,
-        level: 1000,
+        level: ROLES.baseUser.level,
       },
     },
     ssoAccountURL: "",
@@ -52,7 +52,7 @@ const initialState: ProfileStore = {
       role: {
         id: -1,
         name: ROLES.baseUser.value,
-        level: 1000,
+        level: ROLES.baseUser.level,
       },
     }],
     user: {
@@ -66,7 +66,7 @@ const initialState: ProfileStore = {
   roleOptions: [{
     id: -1,
     name: ROLES.baseUser.value,
-    level: 1000,
+    level: ROLES.baseUser.level,
   }],
   org: {
     address: {

--- a/src/store/profile/reducer.ts
+++ b/src/store/profile/reducer.ts
@@ -22,7 +22,7 @@ import { ROLES } from "constants/global";
 const initialState: ProfileStore = {
   members: [{
     Organization: {
-      id: "",
+      id: -1,
       name: "",
     },
     User: {
@@ -30,39 +30,43 @@ const initialState: ProfileStore = {
       name: "",
     },
     Role: {
-      id: "",
+      id: -1,
       name: ROLES.baseUser.value,
+      level: 1000,
     },
   }],
   profile: {
     currentOrg: {
-      id: "",
+      id: -1,
       name: "",
       role: {
-        id: "",
+        id: -1,
         name: ROLES.baseUser.value,
+        level: 1000,
       },
     },
     ssoAccountURL: "",
     organizations: [{
-      id: "",
+      id: -1,
       name: "",
       role: {
-        id: "",
+        id: -1,
         name: ROLES.baseUser.value,
+        level: 1000,
       },
     }],
     user: {
       email: "",
-      id: "",
+      id: -1,
       last_login: "",
       name: "",
       oidcProvider: null,
     },
   },
   roleOptions: [{
-    id: "",
+    id: -1,
     name: ROLES.baseUser.value,
+    level: 1000,
   }],
   org: {
     address: {
@@ -72,7 +76,7 @@ const initialState: ProfileStore = {
       country: "",
     },
     description: "",
-    id: "",
+    id: -1,
     logo: "",
     name: "",
     privacyUrl: "",

--- a/src/store/profile/sagas.ts
+++ b/src/store/profile/sagas.ts
@@ -162,7 +162,7 @@ export function* getProfileSaga() {
     let org = profile.organizations[0];
 
     if (orgId) {
-      const orgFound = profile.organizations.find((org) => org.id === Number(orgId));
+      const orgFound = profile.organizations.find((organization) => organization.id === Number(orgId));
       if (orgFound) {
         org = orgFound;
       }

--- a/src/store/profile/sagas.ts
+++ b/src/store/profile/sagas.ts
@@ -22,7 +22,6 @@ import { Store } from "store/types";
 import { UPDATE_ORG, updateOrgError, updateOrgSuccess } from "./actions/updateOrg";
 import { UPDATE_PROFILE, updateProfileError, updateProfileSuccess } from "./actions/updateProfile";
 import request from "util/request";
-import { getFromStorage } from "util/localStorageActions";
 
 export function* fetchTeamMembersSaga(action: FetchTeamMembersAction) {
   try {
@@ -99,7 +98,7 @@ export function* removeMemberSaga(action: RemoveTeamMemberAction) {
 
     yield put(removeTeamMemberSuccess({}));
     yield put(openNotification("success", i18n.t("messages.removeMember.success"), 3000));
-    if (action.idOfCurrentUser === action.idOfUserToRemove.toString()) yield put(logout({}));
+    if (action.idOfCurrentUser === action.idOfUserToRemove) yield put(logout({}));
   } catch (error) {
     yield put(removeTeamMemberError({ error: error.message || "Invitation failed." }));
     yield put(openNotification("error", i18n.t("messages.removeMember.error"), 3000));
@@ -159,8 +158,23 @@ export function* getProfileSaga() {
       },
     });
 
-    const storedOrg = getFromStorage(LOCAL_STORAGE_KEYS.STORED_ORG)!;
-    const newProfile: Profile = { ...profile, currentOrg: storedOrg };
+    const orgId = localStorage.getItem(LOCAL_STORAGE_KEYS.STORED_ORG);
+    let org = profile.organizations[0];
+
+    if (orgId) {
+      const orgFound = profile.organizations.find((org) => org.id === Number(orgId));
+      if (orgFound) {
+        org = orgFound;
+      }
+    }
+
+    if (!org) {
+      throw new Error("profile has no organizations");
+    }
+
+    localStorage.setItem(LOCAL_STORAGE_KEYS.STORED_ORG, org.id.toString());
+
+    const newProfile: Profile = { ...profile, currentOrg: org };
 
     yield put(getProfileSuccess({ profile: newProfile }));
   } catch (error) {

--- a/src/store/profile/sagas.ts
+++ b/src/store/profile/sagas.ts
@@ -14,7 +14,7 @@ import { FetchRoleOptionsResponse, FetchTeamMembersResponse, GetProfileResponse,
 import { GET_PROFILE, getProfile, getProfileError, getProfileSuccess } from "./actions/getProfile";
 import { handleSessionExpire } from "store/auth/actions/expiredSession";
 import { INVITE_TEAM_MEMBER, inviteTeamMemberError, inviteTeamMemberSuccess } from "./actions/inviteTeamMember";
-import { LOCAL_STORAGE_KEYS, ROLES } from "constants/global";
+import { LOCAL_STORAGE_KEYS } from "constants/global";
 import { logout } from "store/auth/actions/logout";
 import { openNotification } from "store/notificationStack/actions/notification";
 import { removeTeamMemberError, removeTeamMemberSuccess, REMOVE_TEAM_MEMBER } from "./actions/removeTeamMember";
@@ -22,6 +22,7 @@ import { Store } from "store/types";
 import { UPDATE_ORG, updateOrgError, updateOrgSuccess } from "./actions/updateOrg";
 import { UPDATE_PROFILE, updateProfileError, updateProfileSuccess } from "./actions/updateProfile";
 import request from "util/request";
+import { getSelectedOrganization } from "util/getSelectedOrganization";
 
 export function* fetchTeamMembersSaga(action: FetchTeamMembersAction) {
   try {
@@ -158,30 +159,7 @@ export function* getProfileSaga() {
       },
     });
 
-    const orgId = localStorage.getItem(LOCAL_STORAGE_KEYS.STORED_ORG);
-    let org = profile.organizations[0];
-
-    if (orgId) {
-      const orgFound = profile.organizations.find((organization) => organization.id === Number(orgId));
-      if (orgFound) {
-        org = orgFound;
-      }
-    }
-
-    if (!org) {
-      // FIXME: review this - should we really keep an empty organization?
-      org = {
-        id: -1,
-        name: "",
-        role: {
-          id: -1,
-          name: ROLES.baseUser.value,
-          level: ROLES.baseUser.level,
-        },
-      };
-    }
-
-    localStorage.setItem(LOCAL_STORAGE_KEYS.STORED_ORG, org.id.toString());
+    const org = getSelectedOrganization(profile.organizations);
 
     const newProfile: Profile = { ...profile, currentOrg: org };
 

--- a/src/store/profile/sagas.ts
+++ b/src/store/profile/sagas.ts
@@ -169,7 +169,7 @@ export function* getProfileSaga() {
     }
 
     if (!org) {
-      // TODO: review this - should we really keep an empty organization?
+      // FIXME: review this - should we really keep an empty organization?
       org = {
         id: -1,
         name: "",

--- a/src/store/profile/sagas.ts
+++ b/src/store/profile/sagas.ts
@@ -14,7 +14,7 @@ import { FetchRoleOptionsResponse, FetchTeamMembersResponse, GetProfileResponse,
 import { GET_PROFILE, getProfile, getProfileError, getProfileSuccess } from "./actions/getProfile";
 import { handleSessionExpire } from "store/auth/actions/expiredSession";
 import { INVITE_TEAM_MEMBER, inviteTeamMemberError, inviteTeamMemberSuccess } from "./actions/inviteTeamMember";
-import { LOCAL_STORAGE_KEYS } from "constants/global";
+import { LOCAL_STORAGE_KEYS, ROLES } from "constants/global";
 import { logout } from "store/auth/actions/logout";
 import { openNotification } from "store/notificationStack/actions/notification";
 import { removeTeamMemberError, removeTeamMemberSuccess, REMOVE_TEAM_MEMBER } from "./actions/removeTeamMember";
@@ -169,7 +169,16 @@ export function* getProfileSaga() {
     }
 
     if (!org) {
-      throw new Error("profile has no organizations");
+      // TODO: review this - should we really keep an empty organization?
+      org = {
+        id: -1,
+        name: "",
+        role: {
+          id: -1,
+          name: ROLES.baseUser.value,
+          level: ROLES.baseUser.level,
+        },
+      };
     }
 
     localStorage.setItem(LOCAL_STORAGE_KEYS.STORED_ORG, org.id.toString());

--- a/src/store/profile/types.d.ts
+++ b/src/store/profile/types.d.ts
@@ -80,7 +80,7 @@ export type Profile = {
     avatar?: string,
     bio?: string,
     email: string,
-    id: string,
+    id: number,
     "last_login": string,
     mobile?: string,
     name: string,
@@ -89,17 +89,18 @@ export type Profile = {
 }
 
 export type Role = {
-  id: string,
+  id: number,
   name: "admin" | "organizationOwner" | "developer" | "baseUser",
+  level: number,
 }
 
 export type Organization = {
-  id: string,
+  id: number,
   name: string,
 }
 
 export type OrganizationAndRole = {
-  id: string,
+  id: number,
   name: string,
   role: Role,
 }

--- a/src/util/getSelectedOrganization.ts
+++ b/src/util/getSelectedOrganization.ts
@@ -1,0 +1,32 @@
+import { LOCAL_STORAGE_KEYS, ROLES } from "constants/global";
+import { Profile } from "store/profile/types";
+
+/** gets the persisted organization from the provided array of organizations */
+export function getSelectedOrganization(organizations: Profile["organizations"]): Profile["currentOrg"] {
+  const orgId = localStorage.getItem(LOCAL_STORAGE_KEYS.STORED_ORG);
+  let org = organizations[0];
+
+  if (orgId) {
+    const orgFound = organizations.find((organization) => organization.id === Number(orgId));
+    if (orgFound) {
+      org = orgFound;
+    }
+  }
+
+  if (!org) {
+    // review this - should we really keep an empty organization?
+    org = {
+      id: -1,
+      name: "",
+      role: {
+        id: -1,
+        name: ROLES.baseUser.value,
+        level: ROLES.baseUser.level,
+      },
+    };
+  }
+
+  localStorage.setItem(LOCAL_STORAGE_KEYS.STORED_ORG, org.id.toString());
+
+  return org;
+}


### PR DESCRIPTION
This PR fixes a regression bug caused by change to `GET /roles`, that was filtering roles by those with higher level (lower hierarchy) than the one used by the requester.

There was also some refactor needed on id types, Role and how `currentOrg` is persisted to local storage.