### PR TITLE
fix: Added missing API Product chip

### DIFF
--- a/src/components/APIPublications/APIPublications.tsx
+++ b/src/components/APIPublications/APIPublications.tsx
@@ -170,6 +170,14 @@ export const APIPublications: React.FC<APIPublicationsProps> = ({
                   size="small"
                 />
               }
+
+              {apiDetails.version!.deprecated &&
+                <Chip
+                  className={classes.deprecatedChip}
+                  label={t("apiProductDetails.deprecatedAPIProductChip")}
+                  size="small"
+                />
+              }
             </Box>
           </Grid>
 

--- a/src/components/APIPublications/styles.ts
+++ b/src/components/APIPublications/styles.ts
@@ -39,6 +39,7 @@ export default makeStyles((theme) => ({
   prodChip: {
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.common.white,
+    marginRight: theme.spacing(1.5),
   },
 
   selectedTab: {


### PR DESCRIPTION
"Deprecated" chip was missing, so when an API Product's version was deprecated, the UI did not reflect that.