### PR TITLE
fix: Fixed logo and navigation separator contact; Fixed issue with sub-tab underlining

### DIFF
--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -194,11 +194,9 @@ export const Navigation: React.FC<NavigationProps> = ({ contractible = false, cl
         display="flex"
         flexDirection="row"
         flexWrap="nowrap"
-        pb={expand ? 1.625 : undefined}
-        pt={expand ? 2 : undefined}
         style={{
-          marginLeft: !isMaxWidth ? spacing(6) : spacing(4),
-          marginRight: !isMaxWidth ? spacing(6) : spacing(4),
+          margin: !isMaxWidth ? `0px ${spacing(6)}px` : `0px ${spacing(4)}px`,
+          padding: expand ? `${spacing(2)}px 0px ${spacing(1.625)}px 0px` : undefined,
         }}
       >
         {/* Logo & Title */}

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -194,6 +194,7 @@ export const Navigation: React.FC<NavigationProps> = ({ contractible = false, cl
         display="flex"
         flexDirection="row"
         flexWrap="nowrap"
+        pb={expand ? 1.625 : undefined}
         pt={expand ? 2 : undefined}
         style={{
           marginLeft: !isMaxWidth ? spacing(6) : spacing(4),


### PR DESCRIPTION
- Instance owner's logo and company name was touching the navigation line separator.
- Sub-tab underline was not touching the bottom of the background.