### PR TITLE
feat: Inclusion of blueprint app cards to 'Applications' view

### DIFF
--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -17,3 +17,4 @@ function getApiUrl () {
 
 export const API_URL = getApiUrl();
 export const INFORM_URL = process.env.INFORM_URL || "";
+export const BLUEPRINT_APPS_URL = "https://blueprints.apisuite.io/blueprints";

--- a/src/pages/Applications/Applications.tsx
+++ b/src/pages/Applications/Applications.tsx
@@ -24,6 +24,7 @@ import { Organization, Role } from "store/profile/types";
 import { getSections } from "util/extensions";
 import { applicationsSelector } from "./selector";
 import useStyles from "./styles";
+import { getAllBlueprintApps } from "store/applications/actions/getAllBlueprintApps";
 
 export const Applications: React.FC = () => {
   const classes = useStyles();
@@ -33,7 +34,9 @@ export const Applications: React.FC = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const {
-    allUserApps, createUserAppStatus, currentOrganisation, deleteUserAppStatus, org, updateUserAppStatus, user,
+    allBlueprintApps, allUserApps, createUserAppStatus,
+    currentOrganisation, deleteUserAppStatus, org,
+    updateUserAppStatus, user,
   } = useSelector(applicationsSelector);
 
   const MARKETPLACE_SECTION = "SUBBED_MARKETPLACE_APPS";
@@ -188,6 +191,7 @@ export const Applications: React.FC = () => {
       !updateUserAppStatus.isRequesting
     ) {
       dispatch(getAllUserApps({orgID: currentOrganisation.id}));
+      dispatch(getAllBlueprintApps({orgID: currentOrganisation.id}));
     }
   }, [createUserAppStatus, currentOrganisation, deleteUserAppStatus, dispatch, updateUserAppStatus, user]);
 
@@ -286,9 +290,10 @@ export const Applications: React.FC = () => {
         </Box>
 
         {/* Client applications container */}
-        <div>
+        <Box>
           <Grid container spacing={3}>
-            {appCardGenerator(allUserApps)}
+            {appCardGenerator([...allUserApps, ...allBlueprintApps])}
+            
             <Grid item key="appCard-addNew" xs={4}>
               <Card elevation={1}>
                 <CardContent
@@ -310,7 +315,7 @@ export const Applications: React.FC = () => {
               </Card>
             </Grid>
           </Grid>
-        </div>
+        </Box>
 
         {/* Subscribed Marketplace applications container */}
         <Box width={1}>

--- a/src/pages/Applications/selector.ts
+++ b/src/pages/Applications/selector.ts
@@ -7,6 +7,7 @@ export const applicationsSelector = createSelector(
   ({ auth }: Store) => auth,
   (applications, profile, auth) => {
     return {
+      allBlueprintApps: applications.allBlueprintApps,
       allUserApps: applications.userApps,
       createUserAppStatus: applications.createAppStatus,
       currentOrganisation: profile.profile.currentOrg,

--- a/src/store/applications/actions/getAllBlueprintApps.ts
+++ b/src/store/applications/actions/getAllBlueprintApps.ts
@@ -1,0 +1,17 @@
+import { GetAllBlueprintAppsAction, GetAllBlueprintAppsActionError, GetAllBlueprintAppsActionSuccess } from "./types";
+
+export const GET_ALL_BLUEPRINT_APPS = "applications/GET_ALL_BLUEPRINT_APPS";
+export const GET_ALL_BLUEPRINT_APPS_SUCCESS = "applications/GET_ALL_BLUEPRINT_APPS_SUCCESS";
+export const GET_ALL_BLUEPRINT_APPS_ERROR = "applications/GET_ALL_BLUEPRINT_APPS_ERROR";
+
+export function getAllBlueprintApps (payload: Omit<GetAllBlueprintAppsAction, "type">) {
+  return { type: GET_ALL_BLUEPRINT_APPS, ...payload };
+}
+
+export function getAllBlueprintAppsSuccess (payload: Omit<GetAllBlueprintAppsActionSuccess, "type">) {
+  return { type: GET_ALL_BLUEPRINT_APPS_SUCCESS, ...payload };
+}
+
+export function getAllBlueprintAppsError (payload: Omit<GetAllBlueprintAppsActionError, "type">) {
+  return { type: GET_ALL_BLUEPRINT_APPS_ERROR, ...payload };
+}

--- a/src/store/applications/actions/types.d.ts
+++ b/src/store/applications/actions/types.d.ts
@@ -37,7 +37,10 @@ DeleteAppMediaActionError |
 GetAppTypesAction |
 GetAppTypesActionError |
 GetAppTypesActionSuccess |
-ResetUserAppAction
+ResetUserAppAction |
+GetAllBlueprintAppsAction |
+GetAllBlueprintAppsActionSuccess |
+GetAllBlueprintAppsActionError
 
 export type CreateAppAction = {
   type: typeof CREATE_APP,
@@ -194,4 +197,23 @@ export type GetAppTypesActionError = {
 
 export type ResetUserAppAction = {
   type: typeof GET_USER_APP_RESET,
+}
+
+export type GetAllBlueprintAppsAction = {
+  type: typeof GET_ALL_BLUEPRINT_APPS,
+  orgID: number,
+}
+
+export type GetAllBlueprintAppsActionSuccess = {
+  type: typeof GET_ALL_BLUEPRINT_APPS_SUCCESS,
+  allBlueprintApps: BlueprintAppData[],
+}
+
+export type GetAllBlueprintAppsActionError = {
+  type: typeof GET_ALL_BLUEPRINT_APPS_ERROR,
+  allBlueprintApps: AppData[],
+}
+
+export type GetAllBlueprintAppsActionResponse = {
+  data: BlueprintAppData[],
 }

--- a/src/store/applications/reducer.ts
+++ b/src/store/applications/reducer.ts
@@ -11,6 +11,7 @@ import { UPDATE_APP, UPDATE_APP_ERROR, UPDATE_APP_SUCCESS } from "./actions/upda
 import { UPLOAD_APP_MEDIA_SUCCESS } from "./actions/appMediaUpload";
 import { DELETE_APP_MEDIA_SUCCESS } from "./actions/deleteAppMedia";
 import { GET_APP_TYPES_ERROR, GET_APP_TYPES_SUCCESS } from "./actions/getAppTypes";
+import { GET_ALL_BLUEPRINT_APPS_SUCCESS } from "./actions/getAllBlueprintApps";
 
 /** Initial state */
 const initialState: ApplicationsStore = {
@@ -69,6 +70,7 @@ const initialState: ApplicationsStore = {
     isRequesting: false,
   },
   userApps: [],
+  allBlueprintApps: [],
 };
 
 /** Reducer */
@@ -271,6 +273,12 @@ export default function reducer (
     case GET_APP_TYPES_SUCCESS: {
       return update(state, {
         types: { $set: action.types },
+      });
+    }
+
+    case GET_ALL_BLUEPRINT_APPS_SUCCESS: {
+      return update(state, {
+        allBlueprintApps: { $set: action.blueprintApps },
       });
     }
 

--- a/src/store/applications/types.d.ts
+++ b/src/store/applications/types.d.ts
@@ -15,6 +15,7 @@ export interface ApplicationsStore {
   types: AppType[],
   updateAppStatus: Response,
   userApps: AppData[],
+  allBlueprintApps: AppData[],
 }
 
 export interface AppData {
@@ -47,6 +48,16 @@ export interface AppData {
   appTypeId?: number,
 }
 
+export interface BlueprintAppData {
+  app_link: string,
+  app_name: string,
+  configuration: Record<string, unknown>,
+  description: string,
+  id: number,
+  labels: string[],
+  logo: string,
+  overview: string,
+}
 export interface Metadata {
   key: string,
   value: string,


### PR DESCRIPTION
Once the `orgId` is included in the blueprint app's endpoint response, I'll be checking if the code fully works as intended.